### PR TITLE
Build: rebase on operator-framework images

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/water-hole/ansible-operator
+FROM quay.io/operator-framework/ansible-operator
 
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator
+FROM quay.io/operator-framework/ansible-operator:v0.7.0
 
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/


### PR DESCRIPTION
Images on quay.io/operator-framework seems to be mantained and
up to date, compared to the old PoC image.

Signed-off-by: Francesco Romani <fromani@redhat.com>