### PR TITLE
roles: templatevalidator: fix default image repo

### DIFF
--- a/roles/KubevirtTemplateValidator/templates/service.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/service.yaml.j2
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: template-validator
       containers:
         - name: webhook
-          image: {{ ssp_registry | default("kubevirt") }}/{{ validator_image }}:{{ version }}
+          image: {{ ssp_registry | default("quay.io/fromani") }}/{{ validator_image }}:{{ version }}
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
The validator is not moved yet under the kubevirt org

Signed-off-by: Francesco Romani <fromani@redhat.com>