### PR TITLE
Expose more variables to _defaults.yml

### DIFF
--- a/_defaults.yml
+++ b/_defaults.yml
@@ -7,5 +7,7 @@
 # Example:
 #
 # validator_namespace: myproject
-# validator_image: registry.example.com/mine/kubevirt-template-validator:v0.3.0
+# validator_image: registry.example.com/mine/kubevirt-template-validator
+# validator_tag: v0.3.0
+# templates_version: v0.6.0
 ---

--- a/roles/KubevirtCommonTemplatesBundle/defaults/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for KubevirtCommonTemplatesBundle
-version: v0.6.0
+version: "{{ templates_version |default('v0.6.0') }}"
 

--- a/roles/KubevirtTemplateValidator/defaults/main.yml
+++ b/roles/KubevirtTemplateValidator/defaults/main.yml
@@ -3,4 +3,4 @@
 validator_namespace: kubevirt
 validator_image: kubevirt-template-validator
 # this comes from the CR, we must diverge from validator_$SOMETHING standard naming
-version: v0.3.0
+version: "{{ validator_tag |default('v0.3.0') }}"


### PR DESCRIPTION
We need to expose the defaults even when the value is then provided by the CR. Both common templates and the validator are used like that.