### PR TITLE
manifest: drop unneeded 'bind' verb

### DIFF
--- a/deploy/olm-catalog/kubevirt-ssp-operator/1.0.0/kubevirt-ssp-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-ssp-operator/1.0.0/kubevirt-ssp-operator.v1.0.0.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.4.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator"},"spec":{"version":"v0.1.1"}}]'
+    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.4.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator"},"spec":{"version":"v0.3.0"}}]'
     capabilities: Basic Install
   name: kubevirt-ssp-operator.v1.0.0
   namespace: placeholder
@@ -47,7 +47,6 @@ spec:
           - clusterrolebindings
           verbs:
           - create
-          - bind
           - get
           - list
           - watch

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -86,7 +86,6 @@ rules:
   - clusterrolebindings
   verbs:
   - create
-  - bind
   - get
   - list
   - watch

--- a/manifests/olm/bundle/kubevirt-ssp-operator.v1.0.0.csv.yaml
+++ b/manifests/olm/bundle/kubevirt-ssp-operator.v1.0.0.csv.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.4.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator"},"spec":{"version":"v0.1.1"}}]'
+    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.4.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator"},"spec":{"version":"v0.3.0"}}]'
     capabilities: Basic Install
     categories: Virtualization
     description: Manages KubeVirt addons for Scheduling, Scale, Performance
@@ -74,7 +74,6 @@ spec:
           - clusterrolebindings
           verbs:
           - create
-          - bind
           - get
           - list
           - watch

--- a/manifests/v0.1.0/kubevirt-ssp-operator-v0.1.0.yaml
+++ b/manifests/v0.1.0/kubevirt-ssp-operator-v0.1.0.yaml
@@ -92,7 +92,6 @@ rules:
   - clusterrolebindings
   verbs:
   - create
-  - bind
   - get
   - list
   - watch


### PR DESCRIPTION
Testing of the CSV revealed that the 'bind' verb doesn't
pass the validation on OCP - it is not recognized among the
supported verbs.

Search on the historical records doesn't reveal why this verb
was added, and it is not found after a (quick) search in the
k8s/okd docs.

For these reasons, we just drop it.

Signed-off-by: Francesco Romani <fromani@redhat.com>