### PR TITLE
operator: export POD_NAME env var

### DIFF
--- a/cluster/1.0.0/kubevirt-ssp-operator.yaml
+++ b/cluster/1.0.0/kubevirt-ssp-operator.yaml
@@ -213,11 +213,13 @@ spec:
             name: metrics
           imagePullPolicy: Always
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"
-
-     

--- a/deploy/olm-catalog/kubevirt-ssp-operator/1.0.0/kubevirt-ssp-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-ssp-operator/1.0.0/kubevirt-ssp-operator.v1.0.0.clusterserviceversion.yaml
@@ -130,6 +130,10 @@ spec:
             spec:
               containers:
               - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,11 +22,13 @@ spec:
             name: metrics
           imagePullPolicy: Always
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"
-
-     

--- a/manifests/kubevirt-ssp-operator/v1.0.0/kubevirt-ssp-operator.v1.0.0.clusterserviceversion.yaml
+++ b/manifests/kubevirt-ssp-operator/v1.0.0/kubevirt-ssp-operator.v1.0.0.clusterserviceversion.yaml
@@ -157,6 +157,10 @@ spec:
             spec:
               containers:
               - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:


### PR DESCRIPTION
Looks like newer version of the ansible operator require this var to be
set. We comply with this patch.

Signed-off-by: Francesco Romani <fromani@redhat.com>
Bug-Url: https://bugzilla.redhat.com/1704914