### PR TITLE
Change to 'resourceNames' from 'resourceName'

### DIFF
--- a/cluster/1.0.0/kubevirt-ssp-operator.yaml
+++ b/cluster/1.0.0/kubevirt-ssp-operator.yaml
@@ -159,7 +159,7 @@ rules:
   - securitycontextconstraints
   verbs:
   - '*'
-  resourceName:
+  resourceNames:
   - privileged
 
 ---
@@ -183,7 +183,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: kubevirt-ssp-operator
-  namespace: default 
+  namespace: default
 roleRef:
   kind: ClusterRole
   name: kubevirt-ssp-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -153,6 +153,6 @@ rules:
   - securitycontextconstraints
   verbs:
   - '*'
-  resourceName:
+  resourceNames:
   - privileged
 

--- a/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-roles-v0.0.5.yaml
+++ b/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-roles-v0.0.5.yaml
@@ -24,7 +24,7 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
-  resourceName:
+  resourceNames:
   - privileged
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -46,7 +46,7 @@ metadata:
   name: kubevirt-cpu-plugin-configmap
   namespace: {{ meta.namespace }}
 data:
-  cpu-plugin-configmap.yaml: |- 
+  cpu-plugin-configmap.yaml: |-
     obsoleteCPUs:
       - "486"
       - "pentium"


### PR DESCRIPTION
resourceName is not a valid rule name in ClusterRole.
Thus, change to 'resourceNames'

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>