### PR TITLE
pkg: update templates version

### DIFF
--- a/pkg/apis/kubevirt/v1/types.go
+++ b/pkg/apis/kubevirt/v1/types.go
@@ -33,7 +33,7 @@ type KubevirtTemplateValidator struct {
 
 // custom spec
 type VersionSpec struct {
-	Version string `json:"versopm,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -5,7 +5,7 @@ package versions
 import "fmt"
 
 const (
-	KubevirtCommonTemplates   string = "0.4.1"
+	KubevirtCommonTemplates   string = "0.6.0"
 	KubevirtNodeLabeller      string = "0.0.5"
 	KubevirtTemplateValidator string = "0.3.0"
 )


### PR DESCRIPTION
The default version we should ship is v0.6.0

Signed-off-by: Francesco Romani <fromani@redhat.com>