### PR TITLE
validator: prefer deploy in the CR namespace

### DIFF
--- a/deploy/crds/kubevirt_v1_templatevalidator_cr.yaml
+++ b/deploy/crds/kubevirt_v1_templatevalidator_cr.yaml
@@ -2,5 +2,6 @@ apiVersion: kubevirt.io/v1
 kind: KubevirtTemplateValidator
 metadata:
   name: kubevirt-template-validator
+  namespace: kubevirt
 spec:
   version: v0.3.0

--- a/roles/KubevirtTemplateValidator/defaults/main.yml
+++ b/roles/KubevirtTemplateValidator/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 # defaults file for KubevirtTemplateValidator
-validator_namespace: kubevirt
 validator_image: kubevirt-template-validator
 # this comes from the CR, we must diverge from validator_$SOMETHING standard naming
 version: "{{ validator_tag |default('v0.3.0') }}"

--- a/roles/KubevirtTemplateValidator/templates/service.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/service.yaml.j2
@@ -3,7 +3,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: template-validator
-  namespace: "{{ meta.namespace | default(validator_namespace) }}"
+  namespace: "{{ meta.namespace }}"
   labels:
     kubevirt.io: virt-template-validator
 ---
@@ -11,7 +11,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: template-validator
-  namespace: "{{ meta.namespace | default(validator_namespace) }}"
+  namespace: "{{ meta.namespace }}"
   labels:
     kubevirt.io: virt-template-validator
 roleRef:
@@ -21,13 +21,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: template-validator
-    namespace: "{{ meta.namespace | default(validator_namespace) }}"
+    namespace: "{{ meta.namespace }}"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: virt-template-validator
-  namespace: "{{ meta.namespace | default(validator_namespace) }}"
+  namespace: "{{ meta.namespace }}"
   labels:
     kubevirt.io: virt-template-validator
   annotations:
@@ -44,7 +44,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: virt-template-validator
-  namespace: "{{ meta.namespace | default(validator_namespace) }}"
+  namespace: "{{ meta.namespace }}"
   labels:
     name: virt-template-validator
 spec:

--- a/roles/KubevirtTemplateValidator/templates/service.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/service.yaml.j2
@@ -3,7 +3,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: template-validator
-  namespace: "{{ validator_namespace }}"
+  namespace: "{{ meta.namespace | default(validator_namespace) }}"
   labels:
     kubevirt.io: virt-template-validator
 ---
@@ -11,7 +11,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: template-validator
-  namespace: "{{ validator_namespace }}"
+  namespace: "{{ meta.namespace | default(validator_namespace) }}"
   labels:
     kubevirt.io: virt-template-validator
 roleRef:
@@ -21,13 +21,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: template-validator
-    namespace: "{{ validator_namespace }}"
+    namespace: "{{ meta.namespace | default(validator_namespace) }}"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: virt-template-validator
-  namespace: "{{ validator_namespace }}"
+  namespace: "{{ meta.namespace | default(validator_namespace) }}"
   labels:
     kubevirt.io: virt-template-validator
   annotations:
@@ -44,7 +44,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: virt-template-validator
-  namespace: "{{ validator_namespace }}"
+  namespace: "{{ meta.namespace | default(validator_namespace) }}"
   labels:
     name: virt-template-validator
 spec:

--- a/roles/KubevirtTemplateValidator/templates/template-view-role.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/template-view-role.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: template:view
-  namespace: "{{ validator_namespace }}"
+  namespace: "{{ meta.namespace | default(validator_namespace) }}"
   labels:
     kubevirt.io: ""
 rules:

--- a/roles/KubevirtTemplateValidator/templates/template-view-role.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/template-view-role.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: template:view
-  namespace: "{{ meta.namespace | default(validator_namespace) }}"
+  namespace: "{{ meta.namespace }}"
   labels:
     kubevirt.io: ""
 rules:

--- a/roles/KubevirtTemplateValidator/templates/webhook.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/webhook.yaml.j2
@@ -7,7 +7,7 @@ webhooks:
   clientConfig:
     service:
       name: virt-template-validator
-      namespace: "{{ validator_namespace }}"
+      namespace: "{{ meta.namespace | default(validator_namespace) }}"
       path: "/virtualmachine-template-validate"
     caBundle: "{{ cabundle }}"
   rules:

--- a/roles/KubevirtTemplateValidator/templates/webhook.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/webhook.yaml.j2
@@ -7,7 +7,7 @@ webhooks:
   clientConfig:
     service:
       name: virt-template-validator
-      namespace: "{{ meta.namespace | default(validator_namespace) }}"
+      namespace: "{{ meta.namespace }}"
       path: "/virtualmachine-template-validate"
     caBundle: "{{ cabundle }}"
   rules:


### PR DESCRIPTION
Install the validator components into the namespace of the detected CR instead of using the fixed namespace name.
This fixes integration with HCO.

Signed-off-by: Francesco Romani <fromani@redhat.com>