### PR TITLE
validator: implement support for "automatic" version

### DIFF
--- a/roles/KubevirtTemplateValidator/defaults/main.yml
+++ b/roles/KubevirtTemplateValidator/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 # defaults file for KubevirtTemplateValidator
 validator_image: kubevirt-template-validator
-# this comes from the CR, we must diverge from validator_$SOMETHING standard naming
-version: "{{ validator_tag |default('v0.4.8') }}"
+validator_version: "{{ validator_tag |default('v0.4.8') }}"

--- a/roles/KubevirtTemplateValidator/templates/service.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/service.yaml.j2
@@ -58,7 +58,8 @@ spec:
       serviceAccountName: template-validator
       containers:
         - name: webhook
-          image: {{ ssp_registry | default("quay.io/fromani") }}/{{ validator_image }}:{{ version }}
+          # `version` comes from the CR, while `validator_version` is our computed default
+          image: {{ ssp_registry | default("quay.io/fromani") }}/{{ validator_image }}:{{ (version == "automatic") | ternary(validator_version, version) }}
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
Support a special magic value to let the operator decide
the best version to pull.

The alternative is to just leave the "version" field blank
and leverage the defaults we currently have.

Signed-off-by: Francesco Romani <fromani@redhat.com>