### PR TITLE
role: validator: wait for the service to be ready

### DIFF
--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -12,6 +12,7 @@
 # per https://docs.okd.io/latest/dev_guide/secrets.html#service-serving-certificate-secrets
 # *every* pod in the cluster has access to the service-ca.crt, so we can safely use
 # the one inside the operator POD
+  register: tv
 - name: Extract the CA bundle
   set_fact:
     cabundle: "{{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt') | b64encode }}"
@@ -19,3 +20,10 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'webhook.yaml.j2') | from_yaml }}"
+- name: Wait for the template-validator to start
+  set_fact:
+    tv_status: "{{ lookup('k8s', kind=tv.result.kind, namespace=tv.result.metadata.namespace, resource_name=tv.result.metadata.name) | from_yaml }}"
+  retries: 300
+  delay: 10
+  until: tv_status.status.currentNumberScheduled == tv_status.status.numberReady |default(false)
+  when: not wait


### PR DESCRIPTION
Wait for the validator service to be ready before to exit from the ansible role

Signed-off-by: Francesco Romani <fromani@redhat.com>