### PR TITLE
functests: bootstrap and initial batch of tests

### DIFF
--- a/functests/01-test-operator-running.sh
+++ b/functests/01-test-operator-running.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SCRIPTPATH=$( dirname $(readlink -f $0) )
+source ${SCRIPTPATH}/testlib.sh
+
+[ -z ${SSP_OP_POD_NAMESPACE} ] && exit 127
+[ -z ${SSP_OP_POD_NAME} ] && exit 127
+
+SSP_OP_POD_READY=$( oc get pod -o json -n ${SSP_OP_POD_NAMESPACE} ${SSP_OP_POD_NAME} | jq -r '.status.containerStatuses[0].ready' )
+[ "${SSP_OP_POD_READY}" != "true" ] && exit 1
+exit 0

--- a/functests/02-test-deploy-templates-openshift.sh
+++ b/functests/02-test-deploy-templates-openshift.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPTPATH=$( dirname $(readlink -f $0) )
+source ${SCRIPTPATH}/testlib.sh
+
+[ -z ${SSP_OP_POD_NAMESPACE} ] && exit 127
+[ -z ${SSP_OP_POD_NAME} ] && exit 127
+
+RET=1
+TEST_NS="openshift"
+
+oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-versioned-cr.yaml" || exit 2
+# TODO: SSP-operator needs to improve its feedback mechanism
+sleep 10s
+for idx in $( seq 1 30); do
+	NUM=$(oc get templates -n ${TEST_NS} -l "template.kubevirt.io/type=base" -o json | jq ".items | length")
+	if (( "${NUM}" > 0 )); then
+		RET=0
+		break
+	fi
+	sleep 2s
+done
+oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-versioned-cr.yaml" || exit 2
+
+exit $RET

--- a/functests/02-test-deploy-templates-openshift.sh
+++ b/functests/02-test-deploy-templates-openshift.sh
@@ -3,11 +3,8 @@
 SCRIPTPATH=$( dirname $(readlink -f $0) )
 source ${SCRIPTPATH}/testlib.sh
 
-[ -z ${SSP_OP_POD_NAMESPACE} ] && exit 127
-[ -z ${SSP_OP_POD_NAME} ] && exit 127
-
 RET=1
-TEST_NS="openshift"
+TEST_NS="openshift"  # TODO: check this exists?
 
 oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-versioned-cr.yaml" || exit 2
 # TODO: SSP-operator needs to improve its feedback mechanism

--- a/functests/03-test-deploy-templates-different-namespace.sh
+++ b/functests/03-test-deploy-templates-different-namespace.sh
@@ -3,12 +3,6 @@
 SCRIPTPATH=$( dirname $(readlink -f $0) )
 source ${SCRIPTPATH}/testlib.sh
 
-[ -z ${SSP_OP_POD_NAMESPACE} ] && exit 127
-[ -z ${SSP_OP_POD_NAME} ] && exit 127
-
-SSP_OP_POD_READY=$( oc get pod -o json -n ${SSP_OP_POD_NAMESPACE} ${SSP_OP_POD_NAME} | jq -r '.status.containerStatuses[0].ready' )
-[ "${SSP_OP_POD_READY}" != "true" ] && exit 1
-
 RET=1
 TEST_NS=$(uuidgen)
 

--- a/functests/03-test-deploy-templates-different-namespace.sh
+++ b/functests/03-test-deploy-templates-different-namespace.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+SCRIPTPATH=$( dirname $(readlink -f $0) )
+source ${SCRIPTPATH}/testlib.sh
+
+[ -z ${SSP_OP_POD_NAMESPACE} ] && exit 127
+[ -z ${SSP_OP_POD_NAME} ] && exit 127
+
+SSP_OP_POD_READY=$( oc get pod -o json -n ${SSP_OP_POD_NAMESPACE} ${SSP_OP_POD_NAME} | jq -r '.status.containerStatuses[0].ready' )
+[ "${SSP_OP_POD_READY}" != "true" ] && exit 1
+
+RET=1
+TEST_NS=$(uuidgen)
+
+oc create ns ${TEST_NS} || exit 2
+oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-versioned-cr.yaml" || exit 2
+# TODO: SSP-operator needs to improve its feedback mechanism
+sleep 10s
+for idx in $( seq 1 30); do
+	NUM=$(oc get templates -n ${TEST_NS} -l "template.kubevirt.io/type=base" -o json | jq ".items | length")
+	if (( "${NUM}" > 0 )); then
+		RET=0
+		break
+	fi
+	sleep 2s
+done
+oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-versioned-cr.yaml" || exit 2
+oc delete ns ${TEST_NS} || exit 2
+
+exit $RET

--- a/functests/04-test-deploy-template-validator.sh
+++ b/functests/04-test-deploy-template-validator.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 0

--- a/functests/04-test-deploy-templates-operator-namespace.sh
+++ b/functests/04-test-deploy-templates-operator-namespace.sh
@@ -4,7 +4,6 @@ SCRIPTPATH=$( dirname $(readlink -f $0) )
 source ${SCRIPTPATH}/testlib.sh
 
 [ -z ${SSP_OP_POD_NAMESPACE} ] && exit 127
-[ -z ${SSP_OP_POD_NAME} ] && exit 127
 
 RET=1
 TEST_NS="${SSP_OP_POD_NAMESPACE}"

--- a/functests/04-test-deploy-templates-operator-namespace.sh
+++ b/functests/04-test-deploy-templates-operator-namespace.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPTPATH=$( dirname $(readlink -f $0) )
+source ${SCRIPTPATH}/testlib.sh
+
+[ -z ${SSP_OP_POD_NAMESPACE} ] && exit 127
+[ -z ${SSP_OP_POD_NAME} ] && exit 127
+
+RET=1
+TEST_NS="${SSP_OP_POD_NAMESPACE}"
+
+oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-versioned-cr.yaml" || exit 2
+# TODO: SSP-operator needs to improve its feedback mechanism
+sleep 10s
+for idx in $( seq 1 30); do
+	NUM=$(oc get templates -n ${TEST_NS} -l "template.kubevirt.io/type=base" -o json | jq ".items | length")
+	if (( "${NUM}" > 0 )); then
+		RET=0
+		break
+	fi
+	sleep 2s
+done
+oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-versioned-cr.yaml" || exit 2
+
+exit $RET

--- a/functests/05-test-deploy-template-validator.sh
+++ b/functests/05-test-deploy-template-validator.sh
@@ -3,11 +3,8 @@
 SCRIPTPATH=$( dirname $(readlink -f $0) )
 source ${SCRIPTPATH}/testlib.sh
 
-[ -z ${SSP_OP_POD_NAMESPACE} ] && exit 127
-[ -z ${SSP_OP_POD_NAME} ] && exit 127
-
 RET=1
-TEST_NS="kubevirt"
+TEST_NS="${KV_NAMESPACE}"
 
 oc create -n ${TEST_NS} -f "${SCRIPTPATH}/template-validator-unversioned-cr.yaml" || exit 2
 # TODO: SSP-operator needs to improve its feedback mechanism

--- a/functests/05-test-deploy-template-validator.sh
+++ b/functests/05-test-deploy-template-validator.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+SCRIPTPATH=$( dirname $(readlink -f $0) )
+source ${SCRIPTPATH}/testlib.sh
+
+[ -z ${SSP_OP_POD_NAMESPACE} ] && exit 127
+[ -z ${SSP_OP_POD_NAME} ] && exit 127
+
+RET=1
+TEST_NS="kubevirt"
+
+oc create -n ${TEST_NS} -f "${SCRIPTPATH}/template-validator-unversioned-cr.yaml" || exit 2
+# TODO: SSP-operator needs to improve its feedback mechanism
+sleep 10s
+for idx in $( seq 1 30); do
+	VALIDATOR_JSON=$( oc get pods -n ${TEST_NS} -l "kubevirt.io=virt-template-validator" -o json )
+	NUM=$( echo ${VALIDATOR_JSON} | jq '.items | length' )
+	if [ "${NUM}" == "1" ]; then
+		VALIDATOR_POD_JSON="$( echo ${VALIDATOR_JSON} | jq '.items[0]' )"
+		VALIDATOR_READY=$( echo ${VALIDATOR_POD_JSON} | jq .status.containerStatuses[0].ready )
+		if [ "${VALIDATOR_READY}" == "true" ]; then
+			RET=0
+			break
+		fi
+	fi
+	sleep 2s
+done
+oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/template-validator-unversioned-cr.yaml" || exit 2
+
+exit $RET

--- a/functests/06-test-deploy-node-labeller.sh
+++ b/functests/06-test-deploy-node-labeller.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+SCRIPTPATH=$( dirname $(readlink -f $0) )
+source ${SCRIPTPATH}/testlib.sh
+
+[ -z ${KV_NAMESPACE} ] && exit 127
+
+RET=1
+TEST_NS="${KV_NAMESPACE}"
+
+oc create -n ${TEST_NS} -f "${SCRIPTPATH}/node-labeller-unversioned-cr.yaml" || exit 2
+# TODO: SSP-operator needs to improve its feedback mechanism
+sleep 10s
+for idx in $( seq 1 30); do
+	ANNOTATIONS=$( oc get nodes -o json | jq '.items[0].metadata.annotations | keys' )
+	# any random CPU model annotation that *must* be present if everything's OK
+	HAS_CPU=$( echo ${ANNOTATIONS} | jq 'map(endswith("cpu-model-kvm64")) | any' )
+	# any random KVM info annotation that *must* be present if everything's OK
+	HAS_KVM=$( echo ${ANNOTATIONS} | jq 'map(endswith("kvm-info-cap-hyperv-base")) | any' )
+	if [ "${HAS_CPU}" == "true" ] && [ "${HAS_KVM}" == "true" ]; then
+		RET=0
+		break
+	fi
+	sleep 2s
+done
+oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/node-labeller-unversioned-cr.yaml" || exit 2
+
+exit $RET

--- a/functests/06-test-deploy-node-labeller.sh
+++ b/functests/06-test-deploy-node-labeller.sh
@@ -10,7 +10,10 @@ TEST_NS="${KV_NAMESPACE}"
 
 oc create -n ${TEST_NS} -f "${SCRIPTPATH}/node-labeller-unversioned-cr.yaml" || exit 2
 # TODO: SSP-operator needs to improve its feedback mechanism
-sleep 10s
+# fetching node-labeller images may take a while
+
+wait_node_labeller_running ${TEST_NS} 5 60
+
 for idx in $( seq 1 30); do
 	ANNOTATIONS=$( oc get nodes -o json | jq '.items[0].metadata.annotations | keys' )
 	# any random CPU model annotation that *must* be present if everything's OK

--- a/functests/README.md
+++ b/functests/README.md
@@ -1,0 +1,19 @@
+# kubevirt-ssp-operator functional tests
+
+*WARNING*: work in progress. We are still working to make the tests more automated and more robust.
+
+## Preparation
+1. install OKD >= 3.11
+2. install kubevirt >= 0.17
+4. install the SSP operator
+3. ready!
+
+## Warning about [HCO](https://github.com/kubevirt/hyperconverged-cluster-operator)
+
+The HCO installation flow will chain-create the low-level SSP CRs that these tests want to exercise.
+This may likely void functional tests.
+
+## run the tests
+```bash
+./test-runner.sh
+```

--- a/functests/common-templates-versioned-cr.yaml
+++ b/functests/common-templates-versioned-cr.yaml
@@ -1,0 +1,6 @@
+apiVersion: kubevirt.io/v1
+kind: KubevirtCommonTemplatesBundle
+metadata:
+  name: kubevirt-common-template-bundle
+spec:
+  version: v0.6.0

--- a/functests/node-labeller-unversioned-cr.yaml
+++ b/functests/node-labeller-unversioned-cr.yaml
@@ -1,0 +1,4 @@
+apiVersion: kubevirt.io/v1
+kind: KubevirtNodeLabellerBundle
+metadata:
+  name: kubevirt-node-labeller-bundle

--- a/functests/template-validator-unversioned-cr.yaml
+++ b/functests/template-validator-unversioned-cr.yaml
@@ -1,0 +1,4 @@
+apiVersion: kubevirt.io/v1
+kind: KubevirtTemplateValidator
+metadata:
+  name: kubevirt-template-validator

--- a/functests/test-runner.sh
+++ b/functests/test-runner.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+if [ -z "${V}" ]; then
+	V=0
+fi
+
+# checking prereqs
+if [ -z "${OC}" ]; then
+	echo "please define the environment variable 'OC'"
+	exit 2
+fi
+
+MISSING=0
+for EXE in jq; do
+	if [ ! which -- ${EXE} &> /dev/null ]; then
+		echo "missing executable: ${EXE}"
+		MISSING=1
+	fi
+done
+[ "${MISSING}" != "0" ] && exit 4
+
+# we can run the real tests now
+RET=0
+for testscript in $( ls ??-test-*.sh); do
+	testname=$(basename -- "$testscript")
+	testname="${testname%.*}"  # see http://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
+
+	result="???"
+	if [ "${V}" == "0" ]; then
+		./$testscript &> /dev/null
+	else
+		printf "* TESTCASE [%-64s] START\n" $testscript
+		./$testscript
+	fi
+	if [ "$?" == "0" ]; then
+		result="OK"
+	else
+		if [ "$?" == "99" ] ; then
+			result="SKIP"
+		else
+			result="FAILED"
+			RET=1
+		fi
+	fi
+	if [ "${V}" == "0" ]; then
+		printf "* [%-64s] %s\n" $testscript $result
+	else
+		printf "  TESTCASE [%-64s] %s\n" $testscript $result
+	fi
+done
+exit $RET

--- a/functests/testlib.sh
+++ b/functests/testlib.sh
@@ -2,11 +2,21 @@
 
 export SSP_OP_POD_NAME=""
 export SSP_OP_POD_NAMESPACE=""
-export SSP_OP_MANIFEST_JSON=$(oc get pods --all-namespaces -l name=kubevirt-ssp-operator -o json | jq .items[0] )
+export SSP_OP_MANIFEST_JSON=$( oc get pods --all-namespaces -l name=kubevirt-ssp-operator -o json | jq .items[0] )
 
 if [ -z "${SSP_OP_MANIFEST_JSON}" ] || [ "${SSP_OP_MANIFEST_JSON}" == "null" ]; then
 	export SSP_OP_MANIFEST_JSON=""
 else
 	export SSP_OP_POD_NAME=$( echo "${SSP_OP_MANIFEST_JSON}" | jq -r .metadata.name )
 	export SSP_OP_POD_NAMESPACE=$( echo "${SSP_OP_MANIFEST_JSON}" | jq -r .metadata.namespace )
+fi
+
+export KV_NAMESPACE=""
+export KV_OP_POD_NAMESPACE=""
+export KV_OP_MANIFEST_JSON=$( oc get pods --all-namespaces -l 'kubevirt.io=virt-operator' -o json | jq -r '.items[0]' )
+if [ -z "${KV_OP_MANIFEST_JSON}" ] || [ "${KV_OP_MANIFEST_JSON}" == "null" ]; then
+	export KV_OP_MANIFEST_JSON=""
+else
+	export KV_OP_POD_NAMESPACE=$( echo "${KV_OP_MANIFEST_JSON}" | jq -r .metadata.namespace )
+	export KV_NAMESPACE="${KV_OP_POD_NAMESPACE}"
 fi

--- a/functests/testlib.sh
+++ b/functests/testlib.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export SSP_OP_POD_NAME=""
+export SSP_OP_POD_NAMESPACE=""
+export SSP_OP_MANIFEST_JSON=$(oc get pods --all-namespaces -l name=kubevirt-ssp-operator -o json | jq .items[0] )
+
+if [ -z "${SSP_OP_MANIFEST_JSON}" ] || [ "${SSP_OP_MANIFEST_JSON}" == "null" ]; then
+	export SSP_OP_MANIFEST_JSON=""
+else
+	export SSP_OP_POD_NAME=$( echo "${SSP_OP_MANIFEST_JSON}" | jq -r .metadata.name )
+	export SSP_OP_POD_NAMESPACE=$( echo "${SSP_OP_MANIFEST_JSON}" | jq -r .metadata.namespace )
+fi

--- a/functests/testlib.sh
+++ b/functests/testlib.sh
@@ -20,3 +20,51 @@ else
 	export KV_OP_POD_NAMESPACE=$( echo "${KV_OP_MANIFEST_JSON}" | jq -r .metadata.namespace )
 	export KV_NAMESPACE="${KV_OP_POD_NAMESPACE}"
 fi
+
+is_template_validator_running() {
+	NS="--all-namespaces"
+	if [ -n "$1" ]; then
+		NS="-n ${1}"
+	fi
+	local validator_phase=$( oc get pods --selector "kubevirt.io=virt-template-validator" ${NS} -o json | jq -r '.items[0].status.phase' )
+	(( ${V} >= 1 )) && echo "validator phase : ${validator_phase}"
+	if [ "${validator_phase}" == "Running" ]; then
+		return 0
+	fi
+	return 1
+}
+
+is_node_labeller_running() {
+	NS="--all-namespaces"
+	if [ -n "$1" ]; then
+		NS="-n ${1}"
+	fi
+	local labeller_phase=$( oc get pods --selector='app=kubevirt-node-labeller' ${NS} -o json | jq -r '.items[0].status.phase' )
+	(( ${V} >= 1 )) && echo "node-labeller phase: ${labeller_phase}"
+	if [ "${labeller_phase}" == "Running" ]; then
+		return 0
+	fi
+	return 1
+}
+
+wait_template_validator_running() {
+	# $1 passthrough
+	local wait_secs=${2:-2}
+	local max_tries=${3:-15}
+	for num in $( seq 1 ${max_tries} ); do
+		(( ${V} >= 1 )) && echo "waiting for template-validator availability: ${num}/${max_tries}"
+		sleep ${wait_secs}s
+		is_template_validator_running $1 && break
+	done
+}
+
+wait_node_labeller_running() {
+	# $1 passthrough
+	local wait_secs=${2:-2}
+	local max_tries=${3:-15}
+	for num in $( seq 1 ${max_tries} ); do
+		(( ${V} >= 1 )) && echo "waiting for node-labeller availability: ${num}/${max_tries}"
+		sleep ${wait_secs}s
+		is_node_labeller_running $1 && break
+	done
+}


### PR DESCRIPTION
We start testing the deployment of the common templates.
This patch also paves the road for future tests, e.g. about the
validator and the labeller.
We include an initial trivial test for the validator as reference.

The functests assume a running OCP/OKD cluster, see README.md

Running time:
```bash
* [01-test-operator-running.sh                                     ] OK
* [02-test-deploy-templates-openshift.sh                           ] OK
* [03-test-deploy-templates-different-namespace.sh                 ] OK
* [04-test-deploy-templates-operator-namespace.sh                  ] OK
* [05-test-deploy-template-validator.sh                            ] OK
real 167.37
user 14.94
sys 2.67
```

Signed-off-by: Francesco Romani <fromani@redhat.com>