### PR TITLE
hack: env: add scripts to setup test env

### DIFF
--- a/hack/env/deploy/kubevirt-ssp-operator.sh
+++ b/hack/env/deploy/kubevirt-ssp-operator.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+if [ -z ${KUBEVIRT_SSP_OPERATOR_RELEASE} ]; then
+	echo "missing RELEASE"
+	exit 1
+fi
+
+oc create -f cluster/${KUBEVIRT_SSP_OPERATOR_RELEASE}/kubevirt-ssp-operator-crd.yaml 
+oc create -n kubevirt -f deploy/service_account.yaml 
+oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:kubevirt:kubevirt-ssp-operator
+oc create -n kubevirt -f deploy/role.yaml
+oc create -n kubevirt -f deploy/role_binding.yaml
+oc create -n kubevirt -f deploy/operator.yaml

--- a/hack/env/deploy/kubevirt.sh
+++ b/hack/env/deploy/kubevirt.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [ -z ${KUBEVIRT_RELEASE} ]; then
+	echo "missing RELEASE"
+	exit 1
+fi
+
+oc apply -f https://github.com/kubevirt/kubevirt/releases/download/${RELEASE}/kubevirt-operator.yaml
+oc apply -f https://github.com/kubevirt/kubevirt/releases/download/${RELEASE}/kubevirt-cr.yaml
+oc wait -n kubevirt kubevirt.kubevirt.io/kubevirt --for condition=Ready

--- a/hack/env/oc-cluster/down.sh
+++ b/hack/env/oc-cluster/down.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+oc cluster down

--- a/hack/env/oc-cluster/up.sh
+++ b/hack/env/oc-cluster/up.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+oc cluster up
+sleep 20s # FIXME
+
+oc login -u system:admin

--- a/hack/env/setup.sh
+++ b/hack/env/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+export SCRIPTPATH=$( dirname $(readlink -f $0) )
+export KUBEVIRT_RELEASE=${1:-v0.17.0} # note the leading "v"
+export KUBEVIRT_SSP_OPERATOR_RELEASE=${2:-1.0.1}  # note WITHOUT leading "v"
+
+${SCRIPTPATH}/oc-cluster/up.sh
+
+${SCRIPTPATH}/deploy/kubevirt.sh
+${SCRIPTPATH}/deploy/kubevirt-ssp-operator.sh

--- a/hack/env/teardown.sh
+++ b/hack/env/teardown.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+export SCRIPTPATH=$( dirname $(readlink -f $0) )
+export KUBEVIRT_RELEASE=${1:-v0.17.0} # note the leading "v"
+export KUBEVIRT_SSP_OPERATOR_RELEASE=${2:-1.0.1}  # note WITHOUT leading "v"
+
+${SCRIPTPATH}/oc-cluster/down.sh


### PR DESCRIPTION
Add scripts to quickly set up an environment from scratch
suitable to run functests.

Usage, from kubevirt-ssp-operator tree

./hack/env/setup.sh

Supported environments: `oc cluster up`
minishift should follow suit

Signed-off-by: Francesco Romani <fromani@redhat.com>