### PR TITLE
roles: ansible 2.6 compatibility

### DIFF
--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -12,15 +12,9 @@
   register: nl
 
 - name: "Wait for the node-labeller to start"
-  k8s_facts:
-    kind: "{{ nl.result.kind }}"
-    namespace: "{{ nl.result.metadata.namespace }}"
-    api_version: "{{ nl.result.apiVersion }}"
-    name: "{{ nl.result.metadata.name }}"
-  register: nl_status
+  set_fact:
+    nl_status: "{{ lookup('k8s', kind=nl.result.kind, namespace=nl.result.metadata.namespace, resource_name=nl.result.metadata.name) | from_yaml }}"
   retries: 300
   delay: 10
-  until:  nl_status.resources[0].status.currentNumberScheduled == nl_status.resources[0].status.numberReady |default(false)
+  until: nl_status.status.currentNumberScheduled == nl_status.status.numberReady |default(false)
   when: not wait
-
-

--- a/roles/KubevirtRepoInfo/tasks/main.yml
+++ b/roles/KubevirtRepoInfo/tasks/main.yml
@@ -1,15 +1,11 @@
 ---
 # tasks file for KubevirtRepoInfo
 - name: Extract the operator POD info
-  k8s_facts:
-    api_version: v1
-    kind: Pod
-    label_selectors:
-      - name = kubevirt-ssp-operator
-  register: operator_pod
+  set_fact:
+    operator_pod: "{{ lookup('k8s', api_version='v1', kind='Pod', label_selector='name=kubevirt-ssp-operator') | from_yaml }}"
 - name: Extract the image name
   set_fact:
-    operator_image_name: "{{ operator_pod['resources'][0]['spec']['containers'][0]['image'] }}"
+    operator_image_name: "{{ operator_pod['spec']['containers'][0]['image'] }}"
 - name: Extract the SSP registry
   set_fact:
     ssp_registry: "{{ operator_image_name.rsplit('/', 1)[0] }}"

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -3,11 +3,12 @@
 - name: Set template:view role
   k8s:
     state: present
-    definition: "{{ lookup('template', 'template-view-role.yaml.j2') }}"
+    definition: "{{ lookup('template', 'template-view-role.yaml.j2') | from_yaml }}"
 - name: Create the service
   k8s:
     state: present
-    definition: "{{ lookup('template', 'service.yaml.j2') }}"
+    definition: "{{ item | from_yaml }}"
+  with_items: "{{ lookup('template', 'service.yaml.j2').split('\n---\n') | select('search', '(^|\n)[^#]') | list }}"
 # per https://docs.okd.io/latest/dev_guide/secrets.html#service-serving-certificate-secrets
 # *every* pod in the cluster has access to the service-ca.crt, so we can safely use
 # the one inside the operator POD
@@ -17,4 +18,4 @@
 - name: Register the webhook
   k8s:
     state: present
-    definition: "{{ lookup('template', 'webhook.yaml.j2') }}"
+    definition: "{{ lookup('template', 'webhook.yaml.j2') | from_yaml }}"


### PR DESCRIPTION
The 'k8s_facts' module was introduced in ansible 2.7 (see
https://docs.ansible.com/ansible/latest/modules/k8s_facts_module.html)
but the code needs to be ansible 2.6 - compatible

Signed-off-by: Francesco Romani <fromani@redhat.com>