### PR TITLE
virt-launcher image URL is now fetched from enviroment variable

### DIFF
--- a/cluster/1.0.3/kubevirt-ssp-operator-cr.yaml
+++ b/cluster/1.0.3/kubevirt-ssp-operator-cr.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kubevirt.io/v1
+kind: KubevirtCommonTemplatesBundle
+metadata:
+  name: kubevirt-common-template-bundle
+spec:
+  version: v0.6.0
+---
+apiVersion: kubevirt.io/v1
+kind: KubevirtNodeLabellerBundle
+metadata:
+  name: kubevirt-node-labeller-bundle
+spec:
+  version: v0.0.5
+---
+apiVersion: kubevirt.io/v1
+kind: KubevirtTemplateValidator
+metadata:
+  name: kubevirt-template-validator
+  namespace: kubevirt
+spec:
+  version: v0.4.8

--- a/cluster/1.0.3/kubevirt-ssp-operator-crd.yaml
+++ b/cluster/1.0.3/kubevirt-ssp-operator-crd.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtcommontemplatesbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtCommonTemplatesBundle
+    listKind: KubevirtCommonTemplatesBundleList
+    plural: kubevirtcommontemplatesbundles
+    singular: kubevirtcommontemplatesbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtnodelabellerbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtNodeLabellerBundle
+    listKind: KubevirtNodeLabellerBundleList
+    plural: kubevirtnodelabellerbundles
+    singular: kubevirtnodelabellerbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirttemplatevalidators.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtTemplateValidator
+    listKind: KubevirtTemplateValidatorList
+    plural: kubevirttemplatevalidators
+    singular: kubevirttemplatevalidator
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/cluster/1.0.3/kubevirt-ssp-operator.yaml
+++ b/cluster/1.0.3/kubevirt-ssp-operator.yaml
@@ -1,0 +1,151 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-ssp-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt-ssp-operator
+rules:
+- apiGroups:
+  - oauth.openshift.io
+  - template.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - get
+  - patch
+  - list
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - create
+  - get
+  - patch
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  - nodes
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - get
+  - create
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - '*'
+  resourceNames:
+  - privileged
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubevirt-ssp-operator
+subjects:
+- kind: ServiceAccount
+  name: kubevirt-ssp-operator
+  namespace: default 
+roleRef:
+  kind: ClusterRole
+  name: kubevirt-ssp-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubevirt-ssp-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: kubevirt-ssp-operator
+  template:
+    metadata:
+      labels:
+        name: kubevirt-ssp-operator
+    spec:
+      serviceAccountName: kubevirt-ssp-operator
+      containers:
+        - name: kubevirt-ssp-operator
+          #FIXME Replace this with the built image name
+          image: quay.io/fromani/kubevirt-ssp-operator-container:latest
+          ports:
+          - containerPort: 60000
+            name: metrics
+          imagePullPolicy: Always
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: VIRT_LAUNCHER_TAG
+              value: "v0.17.0"
+            - name: OPERATOR_NAME
+              value: "kubevirt-ssp-operator"

--- a/deploy/olm-catalog/kubevirt-ssp-operator/1.0.3/kubevirt-ssp-operator.v1.0.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kubevirt-ssp-operator/1.0.3/kubevirt-ssp-operator.v1.0.3.clusterserviceversion.yaml
@@ -1,0 +1,164 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.6.0"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"version":"v0.4.8"}}]'
+    capabilities: Basic Install
+  name: kubevirt-ssp-operator.v1.0.3
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: KubevirtCommonTemplatesBundle
+      name: kubevirtcommontemplatesbundles.kubevirt.io
+      version: v1
+    - kind: KubevirtNodeLabellerBundle
+      name: kubevirtnodelabellerbundles.kubevirt.io
+      version: v1
+    - kind: KubevirtTemplateValidator
+      name: kubevirttemplatevalidators.kubevirt.io
+      version: v1
+  description: Placeholder description
+  displayName: Kubevirt Ssp Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - oauth.openshift.io
+          - template.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - get
+          - patch
+          - list
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - extensions
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - get
+          - patch
+          - list
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - create
+          - get
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - get
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          - nodes
+          verbs:
+          - create
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - list
+          - get
+          - create
+          - patch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - '*'
+        serviceAccountName: kubevirt-ssp-operator
+      deployments:
+      - name: kubevirt-ssp-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kubevirt-ssp-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: kubevirt-ssp-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                - name: VIRT_LAUNCHER_TAG
+                  value: v0.17.0
+                - name: OPERATOR_NAME
+                  value: kubevirt-ssp-operator
+                image: REPLACE_IMAGE
+                imagePullPolicy: Always
+                name: kubevirt-ssp-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              serviceAccountName: kubevirt-ssp-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  maturity: alpha
+  provider: {}
+  version: 1.0.3

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -28,5 +28,7 @@ spec:
                   fieldPath: metadata.name
             - name: WATCH_NAMESPACE
               value: ""
+            - name: VIRT_LAUNCHER_TAG
+              value: "v0.17.0"
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"

--- a/manifests/kubevirt-ssp-operator/kubevirt-ssp-operator.package.yaml
+++ b/manifests/kubevirt-ssp-operator/kubevirt-ssp-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: kubevirt-ssp-operator
 channels:
 - name: beta
-  currentCSV: kubevirt-ssp-operator.v1.0.2
+  currentCSV: kubevirt-ssp-operator.v1.0.3

--- a/manifests/kubevirt-ssp-operator/v1.0.3/kubevirt-ssp-operator.v1.0.3.clusterserviceversion.yaml
+++ b/manifests/kubevirt-ssp-operator/v1.0.3/kubevirt-ssp-operator.v1.0.3.clusterserviceversion.yaml
@@ -1,0 +1,215 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.6.0"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"version":"v0.4.8"}}]'
+    capabilities: Basic Install
+    categories: Virtualization
+    description: Manages KubeVirt addons for Scheduling, Scale, Performance
+  name: kubevirt-ssp-operator.v1.0.3
+  namespace: kubevirt
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents a deployment of the predefined VM templates
+      displayName: KubeVirt common templates
+      kind: KubevirtCommonTemplatesBundle
+      name: kubevirtcommontemplatesbundles.kubevirt.io
+      specDescriptors:
+      - description: The version of the KubeVirt Templates to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+    - description: Represents a deployment of Node labeller component
+      displayName: KubeVirt Node labeller
+      kind: KubevirtNodeLabellerBundle
+      name: kubevirtnodelabellerbundles.kubevirt.io
+      specDescriptors:
+      - description: The version of the node labeller to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+    - description: Represents a deployment of admission control webhook to validate
+        the KubeVirt templates
+      displayName: KubeVirt Template Validator admission webhook
+      kind: KubevirtTemplateValidator
+      name: kubevirttemplatevalidators.kubevirt.io
+      specDescriptors:
+      - description: The version of the KubeVirt Template Validator to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+  description: KubeVirt Schedule, Scale and Performance Operator
+  displayName: Kubevirt Ssp Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - oauth.openshift.io
+          - template.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - get
+          - patch
+          - list
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - extensions
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - get
+          - patch
+          - list
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - create
+          - get
+          - patch
+        - apiGroups:
+          - ''
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - get
+          - patch
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - configmaps
+          - nodes
+          verbs:
+          - create
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - services
+          verbs:
+          - list
+          - get
+          - create
+          - patch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - '*'
+        serviceAccountName: kubevirt-ssp-operator
+      deployments:
+      - name: kubevirt-ssp-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kubevirt-ssp-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: kubevirt-ssp-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                - name: VIRT_LAUNCHER_TAG
+                  value: v0.17.0
+                - name: OPERATOR_NAME
+                  value: kubevirt-ssp-operator
+                image: REPLACE_IMAGE
+                imagePullPolicy: Always
+                name: kubevirt-ssp-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              serviceAccountName: kubevirt-ssp-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - KubeVirt
+  - Virtualization
+  - Template
+  - Performance
+  - VirtualMachine
+  - Node
+  - Labels
+  labels:
+    alm-owner-kubevirt: kubevirt-ssp-operator
+    operated-by: kubevirt-ssp-operator
+  links:
+  - name: KubeVirt
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/kubevirt
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-ssp-operator
+      operated-by: kubevirt-ssp-operator
+  version: 1.0.3

--- a/manifests/kubevirt-ssp-operator/v1.0.3/kubevirt_v1_commontemplatesbundle_crd.yaml
+++ b/manifests/kubevirt-ssp-operator/v1.0.3/kubevirt_v1_commontemplatesbundle_crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtcommontemplatesbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtCommonTemplatesBundle
+    listKind: KubevirtCommonTemplatesBundleList
+    plural: kubevirtcommontemplatesbundles
+    singular: kubevirtcommontemplatesbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/manifests/kubevirt-ssp-operator/v1.0.3/kubevirt_v1_nodelabellerbundle_crd.yaml
+++ b/manifests/kubevirt-ssp-operator/v1.0.3/kubevirt_v1_nodelabellerbundle_crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtnodelabellerbundles.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtNodeLabellerBundle
+    listKind: KubevirtNodeLabellerBundleList
+    plural: kubevirtnodelabellerbundles
+    singular: kubevirtnodelabellerbundle
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/manifests/kubevirt-ssp-operator/v1.0.3/kubevirt_v1_templatevalidator_crd.yaml
+++ b/manifests/kubevirt-ssp-operator/v1.0.3/kubevirt_v1_templatevalidator_crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirttemplatevalidators.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtTemplateValidator
+    listKind: KubevirtTemplateValidatorList
+    plural: kubevirttemplatevalidators
+    singular: kubevirttemplatevalidator
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/roles/KubevirtNodeLabeller/defaults/main.yml
+++ b/roles/KubevirtNodeLabeller/defaults/main.yml
@@ -8,6 +8,5 @@ kvm_info_nfd_plugin_image: "kvm-info-nfd-plugin"
 kvm_info_nfd_plugin_tag: "v0.4.0"
 kubevirt_cpu_nfd_plugin_image: "kubevirt-cpu-nfd-plugin"
 kubevirt_cpu_nfd_plugin_tag: "v0.0.4"
-libvirt_image: "virt-launcher"
-libvirt_tag: "v0.16.0"
-
+virt_launcher_image: "virt-launcher"
+virt_launcher_tag: "v0.17.0"

--- a/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
+++ b/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
@@ -44,7 +44,7 @@ spec:
               name: cpu-config
 
         - name: libvirt
-          image: {{ ssp_registry | default('kubevirt') }}/{{ libvirt_image }}:{{ libvirt_tag }}
+          image: {{ ssp_registry | default('kubevirt') }}/{{ virt_launcher_image }}:{{ lookup('env','VIRT_LAUNCHER_TAG')| default(virt_launcher_tag, true) }}
           command: ["/bin/sh","-c"]
           args: ["libvirtd -d; chmod o+rw /dev/kvm; virsh domcapabilities --machine q35 --arch x86_64 --virttype kvm > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
           imagePullPolicy: Always


### PR DESCRIPTION
This PR adds ability to set virt-launcher image URL via enviroment variable. 

HCO can now set version of virt-launcher which is used by node-labeller via container enviroment variable.
Thanks to that, node labeller can use the same version of virt-launcher as other components.
When VIRT_LAUNCHER_IMAGE variable is not set, then default value (currently located in roles/KubevirtNodeLabeller/defaults/main.yml) is set.