### PR TITLE
docs: install reuse the travis script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,10 @@ Select the namespace you want to install the operator into. If unsure, the `kube
 export NAMESPACE=kubevirt
 ```
 
-```bash
-oc create -n ${NAMESPACE} -f deploy/service_account.yaml
-oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:${NAMESPACE}:kubevirt-ssp-operator
-oc create -n ${NAMESPACE} -f deploy/role.yaml
-oc create -n ${NAMESPACE} -f deploy/role_binding.yaml
-oc create -n ${NAMESPACE} -f deploy/operator.yaml
-```
+Now, run in your repo:
 
-The `hack/install-operator.sh` automates the above steps for you. Run it from the operator source tree root.
-Usage:
 ```bash
-hack/install-operor.sh $NAMESPACE
+hack/install-operator.sh $NAMESPACE
 ```
 
 ## Generate the YAML manifests

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Select the namespace you want to install the operator into. If unsure, the `kube
 export NAMESPACE=kubevirt
 ```
 
+To avoid incurring in the github API throttling, if you have a [github personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line),
+you should set it now, by doing something like
+```bash
+export GITHUB_TOKEN=...
+```
+
 Now, run in your repo:
 
 ```bash

--- a/hack/install-operator.sh
+++ b/hack/install-operator.sh
@@ -6,6 +6,16 @@ BASEPATH=$( dirname $SELF )
 
 NAMESPACE=${1:-kubevirt}
 
+_curl() {
+	# this dupes the baseline "curl" command line, but is simpler
+	# wrt shell quoting/expansion.
+	if [ -n "${GITHUB_TOKEN}" ]; then
+		curl -H "Authorization: token ${GITHUB_TOKEN}" $@
+	else
+		curl $@
+	fi
+}
+
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_commontemplatesbundle_crd.yaml
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_nodelabellerbundle_crd.yaml
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_templatevalidator_crd.yaml
@@ -13,7 +23,7 @@ oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_templatevalidator_crd.yaml
 LAST_TAG=""
 if [ "${CI}" != "true" ] || [ "${TRAVIS}" != "true" ]; then
 	# TODO: consume releases, not tags
-	LAST_TAG=$( curl -s https://api.github.com/repos/MarSik/kubevirt-ssp-operator/tags | jq -r '.[0].name' )
+	LAST_TAG=$( _curl -s https://api.github.com/repos/MarSik/kubevirt-ssp-operator/tags | jq -r '.[0].name' )
 fi
 
 oc create -n ${NAMESPACE} -f ${BASEPATH}/../deploy/service_account.yaml

--- a/hack/install-operator.sh
+++ b/hack/install-operator.sh
@@ -23,7 +23,8 @@ oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_templatevalidator_crd.yaml
 LAST_TAG=""
 if [ "${CI}" != "true" ] || [ "${TRAVIS}" != "true" ]; then
 	# TODO: consume releases, not tags
-	LAST_TAG=$( _curl -s https://api.github.com/repos/MarSik/kubevirt-ssp-operator/tags | jq -r '.[0].name' )
+	# TODO: check if the github APIs guarantee the ordering
+	LAST_TAG=$( _curl -s https://api.github.com/repos/MarSik/kubevirt-ssp-operator/tags | jq -r '.[].name' | sort -r | head -1 )
 fi
 
 oc create -n ${NAMESPACE} -f ${BASEPATH}/../deploy/service_account.yaml

--- a/hack/install-operator.sh
+++ b/hack/install-operator.sh
@@ -10,20 +10,32 @@ oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_commontemplatesbundle_crd.ya
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_nodelabellerbundle_crd.yaml
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_templatevalidator_crd.yaml
 
+LAST_TAG=""
+if [ "${CI}" != "true" ] || [ "${TRAVIS}" != "true" ]; then
+	# TODO: consume releases, not tags
+	LAST_TAG=$( curl -s https://api.github.com/repos/MarSik/kubevirt-ssp-operator/tags | jq -r '.[0].name' )
+fi
+
 oc create -n ${NAMESPACE} -f ${BASEPATH}/../deploy/service_account.yaml
 oc create -n ${NAMESPACE} -f ${BASEPATH}/../deploy/role.yaml
 
 sed "s|namespace: kubevirt|namespace: ${NAMESPACE}|g" < ${BASEPATH}/../deploy/role_binding.yaml | \
 	oc create -n ${NAMESPACE} -f -
 
-REGISTRY=$(minishift openshift registry)
-sed "s|REPLACE_IMAGE|${REGISTRY}/kubevirt/kubevirt-ssp-operator:devel|g" < ${BASEPATH}/../deploy/operator.yaml | \
-	sed "s|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|g" | \
-	oc create -n ${NAMESPACE} -f -
+if [ "${CI}" == "true" ] && [ "${TRAVIS}" == "true" ]; then
+	REGISTRY=$(minishift openshift registry)
+	sed "s|REPLACE_IMAGE|${REGISTRY}/kubevirt/kubevirt-ssp-operator:devel|g" < ${BASEPATH}/../deploy/operator.yaml | \
+		sed "s|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|g" | \
+		oc create -n ${NAMESPACE} -f -
 
-sleep 5s
+	sleep 5s
 
-oc get pods -n ${NAMESPACE}
-oc get pod -n ${NAMESPACE} -l "name=kubevirt-ssp-operator" -o yaml
+	oc get pods -n ${NAMESPACE}
+	oc get pod -n ${NAMESPACE} -l "name=kubevirt-ssp-operator" -o yaml
 
-sleep 5s
+	sleep 5s
+else
+	sed "s|REPLACE_IMAGE|quay.io/fromani/kubevirt-ssp-operator-container:${LAST_TAG}|g" < ${BASEPATH}/../deploy/operator.yaml | \
+		grep -v FIXME | \
+		oc create -n ${NAMESPACE} -f -
+fi


### PR DESCRIPTION
With minor changes, we can provide a simple install
script for everyone brave enough to install the
SSP-operator in their cluster.

This simplifies the install process quite a lot
with no real drawbacks.

Signed-off-by: Francesco Romani <fromani@redhat.com>