### PR TITLE
manifests: install: fix RBAC permissions

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kubevirt-ssp-operator
 rules:
 - apiGroups:
+  - kubevirt.io
   - oauth.openshift.io
   - template.openshift.io
   resources:
@@ -17,8 +18,10 @@ rules:
   verbs:
   - create
   - get
-  - patch
   - list
+  - watch
+  - patch
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -29,53 +32,56 @@ rules:
   - list
   - watch
   - patch
+  - update
 - apiGroups:
   - extensions
   - apps
   resources:
   - deployments
   - replicasets
-  verbs:
-  - create
-  - get
-  - patch
-  - list
-- apiGroups:
-  - apps
-  resources:
   - daemonsets
+  - statefulsets
   verbs:
-  - create
-  - get
-  - patch
+  - '*'
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
-  verbs:
-  - create
-  - get
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - pods
   - configmaps
   - nodes
+  - endpoints
+  - events
+  - secrets
   verbs:
   - create
   - get
   - patch
   - update
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - '*'
 - apiGroups:
   - ""
   resources:
   - services
   verbs:
-  - list
-  - get
   - create
+  - get
+  - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -74,6 +74,7 @@ rules:
   - get
   - list
   - patch
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: kubevirt-ssp-operator
-  namespace: default 
+  namespace: kubevirt
 roleRef:
   kind: ClusterRole
   name: kubevirt-ssp-operator

--- a/hack/install-operator.sh
+++ b/hack/install-operator.sh
@@ -6,17 +6,17 @@ BASEPATH=$( dirname $SELF )
 
 NAMESPACE=${1:-kubevirt}
 
-REGISTRY=$(minishift openshift registry)
-
-oc create -n ${NAMESPACE} -f ${BASEPATH}/../deploy/service_account.yaml
-oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:${NAMESPACE}:kubevirt-ssp-operator
-oc create -n ${NAMESPACE} -f ${BASEPATH}/../deploy/role.yaml
-oc create -n ${NAMESPACE} -f ${BASEPATH}/../deploy/role_binding.yaml
-
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_commontemplatesbundle_crd.yaml
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_nodelabellerbundle_crd.yaml
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_templatevalidator_crd.yaml
 
+oc create -n ${NAMESPACE} -f ${BASEPATH}/../deploy/service_account.yaml
+oc create -n ${NAMESPACE} -f ${BASEPATH}/../deploy/role.yaml
+
+sed "s|namespace: kubevirt|namespace: ${NAMESPACE}|g" < ${BASEPATH}/../deploy/role_binding.yaml | \
+	oc create -n ${NAMESPACE} -f -
+
+REGISTRY=$(minishift openshift registry)
 sed "s|REPLACE_IMAGE|${REGISTRY}/kubevirt/kubevirt-ssp-operator:devel|g" < ${BASEPATH}/../deploy/operator.yaml | \
 	sed "s|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|g" | \
 	oc create -n ${NAMESPACE} -f -


### PR DESCRIPTION
The PR https://github.com/MarSik/kubevirt-ssp-operator/pull/27
 had a bug which was not evident on standalone installation, because in
the install script we granted too broad permissions.

This became evident when deployed under HCO.
This PR aims to fix the RBAC permission issues without using too broad
permission sets.

Signed-off-by: Francesco Romani <fromani@redhat.com>