### PR TITLE
version of ssp components can be now set via operator enviroment variable

### DIFF
--- a/_defaults.yml
+++ b/_defaults.yml
@@ -11,3 +11,11 @@
 # validator_tag: v0.4.8
 # templates_version: v0.6.0
 ---
+#node-labeller
+kubevirt_node_labeller_tag: "{{ lookup('env','NODE_LABELLER_TAG')| default('v0.1.0', true) }}"
+kvm_info_nfd_plugin_tag: "{{ lookup('env','KVM_INFO_TAG')| default('v0.5.7', true) }}"
+kubevirt_cpu_nfd_plugin_tag: "{{ lookup('env','CPU_PLUGIN_TAG')| default('v0.1.0', true) }}"
+virt_launcher_tag: "{{ lookup('env','VIRT_LAUNCHER_TAG')| default('v0.18.0', true) }}"
+
+#validator
+validator_tag: "{{ lookup('env','VALIDATOR_TAG')| default('v0.6.1', true) }}"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -28,7 +28,15 @@ spec:
                   fieldPath: metadata.name
             - name: WATCH_NAMESPACE
               value: ""
+            - name: KVM_INFO_TAG
+              value: ""
+            - name: VALIDATOR_TAG
+              value: ""
             - name: VIRT_LAUNCHER_TAG
-              value: "v0.17.0"
+              value: ""
+            - name: NODE_LABELLER_TAG
+              value: ""
+            - name: CPU_PLUGIN_TAG
+              value: ""
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"

--- a/roles/KubevirtNodeLabeller/defaults/main.yml
+++ b/roles/KubevirtNodeLabeller/defaults/main.yml
@@ -3,10 +3,10 @@
 wait: true
 
 kubevirt_node_labeller_image: "node-labeller"
-kubevirt_node_labeller_tag: "v0.1.0"
+kubevirt_node_labeller_tag: "latest"
 kvm_info_nfd_plugin_image: "kvm-info-nfd-plugin"
-kvm_info_nfd_plugin_tag: "v0.5.7"
+kvm_info_nfd_plugin_tag: "latest"
 kubevirt_cpu_nfd_plugin_image: "cpu-nfd-plugin"
-kubevirt_cpu_nfd_plugin_tag: "v0.1.0"
+kubevirt_cpu_nfd_plugin_tag: "latest"
 virt_launcher_image: "virt-launcher"
-virt_launcher_tag: "v0.18.0"
+virt_launcher_tag: "latest"

--- a/roles/KubevirtNodeLabeller/defaults/main.yml
+++ b/roles/KubevirtNodeLabeller/defaults/main.yml
@@ -2,11 +2,11 @@
 # defaults file for KubevirtNodeLabeller
 wait: true
 
-kubevirt_node_labeller_image: "kubevirt-node-labeller"
-kubevirt_node_labeller_tag: "v0.0.5"
+kubevirt_node_labeller_image: "node-labeller"
+kubevirt_node_labeller_tag: "v0.1.0"
 kvm_info_nfd_plugin_image: "kvm-info-nfd-plugin"
-kvm_info_nfd_plugin_tag: "v0.4.0"
-kubevirt_cpu_nfd_plugin_image: "kubevirt-cpu-nfd-plugin"
-kubevirt_cpu_nfd_plugin_tag: "v0.0.4"
+kvm_info_nfd_plugin_tag: "v0.5.7"
+kubevirt_cpu_nfd_plugin_image: "cpu-nfd-plugin"
+kubevirt_cpu_nfd_plugin_tag: "v0.1.0"
 virt_launcher_image: "virt-launcher"
-virt_launcher_tag: "v0.17.0"
+virt_launcher_tag: "v0.18.0"

--- a/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
+++ b/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
@@ -18,13 +18,13 @@ spec:
       serviceAccount: kubevirt-node-labeller
       containers:
       - name: kubevirt-node-labeller-sleeper
-        image: {{ ssp_registry | default('quay.io/ksimon') }}/{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
+        image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
         command: ["sleep"]
         args: ["infinity"]
       initContainers:
 
         - name: kvm-info-nfd-plugin
-          image: {{ ssp_registry | default('quay.io/fromani') }}/{{ kvm_info_nfd_plugin_image }}:{{ kvm_info_nfd_plugin_tag }}
+          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ kvm_info_nfd_plugin_image }}:{{ kvm_info_nfd_plugin_tag }}
           command: ["/bin/sh","-c"]
           args: ["cp /usr/bin/kvm-caps-info-nfd-plugin /etc/kubernetes/node-feature-discovery/source.d/;"]
           imagePullPolicy: Always
@@ -33,9 +33,9 @@ spec:
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
 
         - name: kubevirt-cpu-nfd-plugin
-          image: {{ ssp_registry | default('quay.io/ksimon') }}/{{ kubevirt_cpu_nfd_plugin_image }}:{{ kubevirt_cpu_nfd_plugin_tag }}
+          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ kubevirt_cpu_nfd_plugin_image }}:{{ kubevirt_cpu_nfd_plugin_tag }}
           command: ["/bin/sh","-c"]
-          args: ["cp /plugin/dest/kubevirt-cpu-nfd-plugin /etc/kubernetes/node-feature-discovery/source.d/; cp /config/cpu-plugin-configmap.yaml /etc/kubernetes/node-feature-discovery/source.d/cpu-plugin-configmap.yaml;"]
+          args: ["cp /plugin/dest/cpu-nfd-plugin /etc/kubernetes/node-feature-discovery/source.d/; cp /config/cpu-plugin-configmap.yaml /etc/kubernetes/node-feature-discovery/source.d/cpu-plugin-configmap.yaml;"]
           imagePullPolicy: Always
           volumeMounts:
             - name: nfd-source
@@ -44,7 +44,7 @@ spec:
               name: cpu-config
 
         - name: libvirt
-          image: {{ ssp_registry | default('kubevirt') }}/{{ virt_launcher_image }}:{{ lookup('env','VIRT_LAUNCHER_TAG')| default(virt_launcher_tag, true) }}
+          image: {{ ssp_registry | default('kubevirt') }}/{{ virt_launcher_image }}:{{ virt_launcher_tag }}
           command: ["/bin/sh","-c"]
           args: ["libvirtd -d; chmod o+rw /dev/kvm; virsh domcapabilities --machine q35 --arch x86_64 --virttype kvm > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
           imagePullPolicy: Always
@@ -64,7 +64,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: {{ ssp_registry | default('quay.io/ksimon') }}/{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
+          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
This PR enables to set version of ssp components via container enviroment variables.

Updated node labeller, validator to new version
