### PR TITLE
build: don't include py source code in the image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 operator-sdk
 _out
+build/preprocess_template.pyc

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ REGISTRY_IMAGE ?= kubevirt-ssp-operator-registry
 container-build: container-build-operator container-build-registry
 
 container-build-operator:
+	python -m compileall build/preprocess_template.py
 	docker build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) .
+	rm -f build/preprocess_template.pyc
 
 container-build-registry:
 	docker build -f build/Dockerfile.registry -t $(IMAGE_REGISTRY)/$(REGISTRY_IMAGE):$(IMAGE_TAG) .

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,6 +5,6 @@ COPY playbooks/ ${HOME}/
 COPY watches.yaml ${HOME}/watches.yaml
 COPY _defaults.yml ${HOME}/_defaults.yml
 
-COPY build/preprocess_template.py ${HOME}/
+COPY build/preprocess_template.pyc ${HOME}/
 COPY patch.yaml ${HOME}/
-RUN python ${HOME}/preprocess_template.py ${HOME}/patch.yaml ${HOME}/roles/KubevirtCommonTemplatesBundle/files/
+RUN python ${HOME}/preprocess_template.pyc ${HOME}/patch.yaml ${HOME}/roles/KubevirtCommonTemplatesBundle/files/


### PR DESCRIPTION
Let's have a binary-only top-level image.
Assuming that ansible playbooks don't count as source code :)

Signed-off-by: Francesco Romani <fromani@redhat.com>