### PR TITLE
Add csv-generator logic to ssp operator container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE_TAG ?= latest
 OPERATOR_IMAGE ?= kubevirt-ssp-operator-container
 REGISTRY_IMAGE ?= kubevirt-ssp-operator-registry
 
-container-build: container-build-operator container-build-registry
+container-build: csv-generator container-build-operator container-build-registry
 
 container-build-operator:
 	docker build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) .
@@ -25,6 +25,9 @@ container-push-registry:
 container-release:
 	./hack/docker-push.sh $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) $(IMAGE_REGISTRY)/$(REGISTRY_IMAGE):$(IMAGE_TAG)
 
+csv-generator: operator-sdk
+	./build/make-csv-generator.sh
+
 operator-sdk:
 	curl -JL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-x86_64-linux-gnu -o operator-sdk
 	chmod 0755 operator-sdk
@@ -35,7 +38,7 @@ manifests-prepare:
 manifests-cleanup:
 	rm -rf _out
 
-manifests: manifests-cleanup manifests-prepare operator-sdk
+manifests: csv-generator manifests-cleanup manifests-prepare operator-sdk
 	./build/make-manifests.sh ${IMAGE_TAG}
 	./hack/release-manifests.sh ${IMAGE_TAG}
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/operator-framework/ansible-operator:v0.7.0
 
+LABEL org.kubevirt.hco.csv-generator.v1="/usr/bin/csv-generator"
+
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/
 COPY watches.yaml ${HOME}/watches.yaml

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,6 +5,7 @@ COPY playbooks/ ${HOME}/
 COPY watches.yaml ${HOME}/watches.yaml
 COPY _defaults.yml ${HOME}/_defaults.yml
 
+COPY deploy/crds ${HOME}/deploy/crds
 COPY manifests/generated ${HOME}/manifests/generated
 COPY build/csv-generator.sh /usr/bin/csv-generator
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,6 +5,9 @@ COPY playbooks/ ${HOME}/
 COPY watches.yaml ${HOME}/watches.yaml
 COPY _defaults.yml ${HOME}/_defaults.yml
 
+COPY manifests/generated ${HOME}/manifests/generated
+COPY build/csv-generator.sh /usr/bin/csv-generator
+
 COPY build/preprocess_template.py ${HOME}/
 COPY patch.yaml ${HOME}/
 RUN python ${HOME}/preprocess_template.py ${HOME}/patch.yaml ${HOME}/roles/KubevirtCommonTemplatesBundle/files/

--- a/build/Dockerfile.registry
+++ b/build/Dockerfile.registry
@@ -3,7 +3,8 @@ FROM quay.io/openshift/origin-operator-registry
 COPY manifests /registry
 
 # Initialize the database
-RUN initializer --manifests /registry --output bundles.db
+RUN rm -rf /registry/generated && \
+    initializer --manifests /registry --output bundles.db
 
 # There are multiple binaries in the origin-operator-registry
 # We want the registry-server

--- a/build/csv-generator.sh
+++ b/build/csv-generator.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -e
+
+MANIFESTS_GENERATED_DIR="manifests/generated"
+if ! [ -d $MANIFESTS_GENERATED_DIR ]; then
+    MANIFESTS_GENERATED_DIR="${HOME}/manifests/generated"
+fi
+MANIFESTS_GENERATED_CSV=${MANIFESTS_GENERATED_DIR}/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+TMP_FILE=$(mktemp)
+
+replace_env_var() {
+    local value_offset="                  "
+    local key=$1
+    local var=$2
+    sed -i "s/- name: ${key}/- name: $1\n${value_offset}value: \"${var}\"/g" ${TMP_FILE}
+}
+
+help_text() {
+    echo "USAGE: csv-generator --csv-version=<version> --namespace=<namespace> --operator-image=<operator image> [optional args]"
+    echo ""
+    echo "ARGS:"
+    echo "  --csv-version:    (REQUIRED) The version of the CSV file"
+    echo "  --namespace:      (REQUIRED) The namespace set on the CSV file"
+    echo "  --operator-image: (REQUIRED) The operator container image to use in the CSV file"
+    echo "  --watch-namespace:   (OPTIONAL)"
+    echo "  --kvm-info-tag:      (OPTIONAL)"
+    echo "  --validator-tag:     (OPTIONAL)"
+    echo "  --virt-launcher-tag: (OPTIONAL)"
+    echo "  --node-labeller-tag: (OPTIONAL)"
+    echo "  --cpu-plugin-tag:    (OPTIONAL)"
+}
+
+# REQUIRED ARGS
+CSV_VERSION=""
+NAMESPACE=""
+OPERATOR_IMAGE=""
+
+# OPTIONAL ARGS
+WATCH_NAMESPACE=""
+KVM_INFO_TAG=""
+VALIDATOR_TAG=""
+VIRT_LAUNCHER_TAG=""
+NODE_LABELLER_TAG=""
+CPU_PLUGIN_TAG=""
+
+while (( "$#" )); do
+    ARG=`echo $1 | awk -F= '{print $1}'`
+    VAL=`echo $1 | awk -F= '{print $2}'`
+    shift
+
+    case "$ARG" in
+    --csv-version)
+        CSV_VERSION=$VAL
+        ;;
+    --namespace)
+        NAMESPACE=$VAL
+        ;;
+    --operator-image)
+        OPERATOR_IMAGE=$VAL
+        ;;
+    --watch-namespace)
+        WATCH_NAMESPACE=$VAL
+        ;;
+    --kvm-info-tag)
+        KVM_INFO_TAG=$VAL
+        ;;
+    --validator-tag)
+        VALIDATOR_TAG=$VAL
+        ;;
+    --virt-launcher-tag)
+        VIRT_LAUNCHER_TAG=$VAL
+        ;;
+    --node-labeller-tag)
+        NODE_LABELLER_TAG=$VAL
+        ;;
+    --cpu-plugin-tag)
+        CPU_PLUGIN_TAG=$VAL
+        ;;
+    --)
+        break
+        ;;
+    *) # unsupported flag
+        echo "Error: Unsupported flag $ARG" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if [ -z "$CSV_VERSION" ] || [ -z "$NAMESPACE" ] || [ -z "$OPERATOR_IMAGE" ]; then
+    echo "Error: Missing required arguments"
+    help_text
+    exit 1
+fi
+
+cp ${MANIFESTS_GENERATED_CSV} ${TMP_FILE}
+
+# replace placeholder version with a human readable variable name
+# that will be used later on by csv-generator
+sed -i "s/PLACEHOLDER_CSV_VERSION/${CSV_VERSION}/g" ${TMP_FILE}
+sed -i "s/namespace: placeholder/${NAMESPACE}/g" ${TMP_FILE}
+sed -i "s/REPLACE_IMAGE/${OPERATOR_IMAGE}/g" ${TMP_FILE}
+
+replace_env_var "WATCH_NAMESPACE" $WATCH_NAMESPACE
+replace_env_var "KVM_INFO_TAG" $KVM_INFO_TAG
+replace_env_var "VALIDATOR_TAG" $VALIDATOR_TAG
+replace_env_var "VIRT_LAUNCHER_TAG" $VIRT_LAUNCHER_TAG
+replace_env_var "NODE_LABELLER_TAG" $NODE_LABELLER_TAG
+replace_env_var "CPU_PLUGIN_TAG" $CPU_PLUGIN_TAG
+
+cat ${TMP_FILE}
+rm ${TMP_FILE}

--- a/build/csv-generator.sh
+++ b/build/csv-generator.sh
@@ -3,8 +3,10 @@
 set -e
 
 MANIFESTS_GENERATED_DIR="manifests/generated"
+CRDS_DIR="deploy/crds"
 if ! [ -d $MANIFESTS_GENERATED_DIR ]; then
     MANIFESTS_GENERATED_DIR="${HOME}/manifests/generated"
+    CRDS_DIR="${HOME}/deploy/crds"
 fi
 MANIFESTS_GENERATED_CSV=${MANIFESTS_GENERATED_DIR}/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
 TMP_FILE=$(mktemp)
@@ -108,5 +110,11 @@ replace_env_var "VIRT_LAUNCHER_TAG" $VIRT_LAUNCHER_TAG
 replace_env_var "NODE_LABELLER_TAG" $NODE_LABELLER_TAG
 replace_env_var "CPU_PLUGIN_TAG" $CPU_PLUGIN_TAG
 
+# dump CSV and CRD manifests to stdout
+echo "---"
 cat ${TMP_FILE}
+for CRD in $( ls deploy/crds/kubevirt_*crd.yaml ); do
+	echo "---"
+	cat ${CRD}
+done
 rm ${TMP_FILE}

--- a/build/make-csv-generator.sh
+++ b/build/make-csv-generator.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+if [ -x "${BASEPATH}/../operator-sdk" ]; then
+       OPERATOR_SDK="${BASEPATH}/../operator-sdk"
+else       
+    which operator-sdk &> /dev/null || {
+        echo "operator-sdk not found (see https://github.com/operator-framework/operator-sdk)"
+        exit 1
+    }
+    OPERATOR_SDK="operator-sdk"
+fi
+
+MANIFESTS_GENERATED_DIR="manifests/generated"
+MANIFESTS_GENERATED_CSV=${MANIFESTS_GENERATED_DIR}/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+PLACEHOLDER_CSV_VERSION="9999.9999.9999"
+
+# Create CSV with placeholder version. The version
+# has to be semver compatible in order for the 
+# operator sdk to create it for us. That's why we
+# are using the absurd 9999.9999.9999 version here. 
+${OPERATOR_SDK} olm-catalog gen-csv --csv-version ${PLACEHOLDER_CSV_VERSION}
+
+# Move CSV to generated folder
+mv deploy/olm-catalog/kubevirt-ssp-operator/${PLACEHOLDER_CSV_VERSION}/kubevirt-ssp-operator.v${PLACEHOLDER_CSV_VERSION}.clusterserviceversion.yaml $MANIFESTS_GENERATED_CSV
+
+# cleanup placeholder version's deployment dir
+rm -rf mv deploy/olm-catalog/kubevirt-ssp-operator/${PLACEHOLDER_CSV_VERSION}
+
+# replace placeholder version with a human readable variable name
+# that will be used later on by csv-generator
+sed -i "s/${PLACEHOLDER_CSV_VERSION}/PLACEHOLDER_CSV_VERSION/g" $MANIFESTS_GENERATED_CSV 
+
+# inject the CRD and Description related data into the CSV
+cp $MANIFESTS_GENERATED_CSV ${MANIFESTS_GENERATED_CSV}.tmp
+./build/update-olm.py ${MANIFESTS_GENERATED_CSV}.tmp > ${MANIFESTS_GENERATED_CSV}
+rm ${MANIFESTS_GENERATED_CSV}.tmp
+

--- a/build/make-manifests.sh
+++ b/build/make-manifests.sh
@@ -14,16 +14,6 @@ MANIFESTS_DIR="manifests/kubevirt-ssp-operator"
 MANIFESTS_VERSIONED_DIR="${MANIFESTS_DIR}/${TAG}"
 IMAGE_PATH="quay.io/fromani/kubevirt-ssp-operator-container:latest"
 
-if [ -x "${BASEPATH}/../operator-sdk" ]; then
-       OPERATOR_SDK="${BASEPATH}/../operator-sdk"
-else       
-	which operator-sdk &> /dev/null || {
-		echo "operator-sdk not found (see https://github.com/operator-framework/operator-sdk)"
-		exit 1
-	}
-	OPERATOR_SDK="operator-sdk"
-fi
-
 HAVE_COURIER=0
 if which operator-courier &> /dev/null; then
 	HAVE_COURIER=1
@@ -53,13 +43,7 @@ for MF in deploy/service_account.yaml deploy/role.yaml deploy/role_binding.yaml 
 done
 ) > ${CLUSTER_VERSIONED_DIR}/kubevirt-ssp-operator.yaml
 
-# TODO: we should use --from-version
-# note: this creates under deploy/olm-catalog ...
-${OPERATOR_SDK} olm-catalog gen-csv --csv-version ${VERSION}
-
-./build/update-olm.py \
-	deploy/olm-catalog/kubevirt-ssp-operator/${VERSION}/kubevirt-ssp-operator.${TAG}.clusterserviceversion.yaml > \
-	${MANIFESTS_VERSIONED_DIR}/kubevirt-ssp-operator.${TAG}.clusterserviceversion.yaml
+./build/csv-generator.sh --csv-version=${VERSION} --namespace=placeholder --operator-image=REPLACE_IMAGE > ${MANIFESTS_VERSIONED_DIR}/kubevirt-ssp-operator.${TAG}.clusterserviceversion.yaml
 
 # caution: operator-courier (as in 5a4852c) wants *one* entity per yaml file (e.g. it does NOT use safe_load_all)
 for CRD in $( ls deploy/crds/kubevirt_*crd.yaml ); do

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.6.0"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"version":"v0.4.8"}}]'
+    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.6.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"version":"v0.6.1"}}]'
     capabilities: Basic Install
     categories: Virtualization
     description: Manages KubeVirt addons for Scheduling, Scale, Performance
@@ -18,6 +18,17 @@ spec:
       name: kubevirtcommontemplatesbundles.kubevirt.io
       specDescriptors:
       - description: The version of the KubeVirt Templates to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+    - description: Provide aggregation rules for core kubevirt metrics
+      displayName: KubeVirt Metric Aggregation
+      kind: KubevirtMetricsAggregation
+      name: kubevirtmetricsaggregations.kubevirt.io
+      specDescriptors:
+      - description: The version of the aggregation rules to deploy
         displayName: Version
         path: version
         x-descriptors:
@@ -63,6 +74,16 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - get
+          - list
+          - patch
           - watch
         - apiGroups:
           - rbac.authorization.k8s.io

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -1,0 +1,222 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.6.0"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"version":"v0.4.8"}}]'
+    capabilities: Basic Install
+    categories: Virtualization
+    description: Manages KubeVirt addons for Scheduling, Scale, Performance
+  name: kubevirt-ssp-operator.vPLACEHOLDER_CSV_VERSION
+  namespace: kubevirt
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents a deployment of the predefined VM templates
+      displayName: KubeVirt common templates
+      kind: KubevirtCommonTemplatesBundle
+      name: kubevirtcommontemplatesbundles.kubevirt.io
+      specDescriptors:
+      - description: The version of the KubeVirt Templates to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+    - description: Represents a deployment of Node labeller component
+      displayName: KubeVirt Node labeller
+      kind: KubevirtNodeLabellerBundle
+      name: kubevirtnodelabellerbundles.kubevirt.io
+      specDescriptors:
+      - description: The version of the node labeller to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+    - description: Represents a deployment of admission control webhook to validate
+        the KubeVirt templates
+      displayName: KubeVirt Template Validator admission webhook
+      kind: KubevirtTemplateValidator
+      name: kubevirttemplatevalidators.kubevirt.io
+      specDescriptors:
+      - description: The version of the KubeVirt Template Validator to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.ssp:version
+      version: v1
+  description: KubeVirt Schedule, Scale and Performance Operator
+  displayName: Kubevirt Ssp Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - kubevirt.io
+          - template.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - watch
+          - patch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - extensions
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          - daemonsets
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - serviceaccounts
+          - configmaps
+          - services
+          verbs:
+          - create
+          - get
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - nodes
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: kubevirt-ssp-operator
+      deployments:
+      - name: kubevirt-ssp-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kubevirt-ssp-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: kubevirt-ssp-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: WATCH_NAMESPACE
+                - name: KVM_INFO_TAG
+                - name: VALIDATOR_TAG
+                - name: VIRT_LAUNCHER_TAG
+                - name: NODE_LABELLER_TAG
+                - name: CPU_PLUGIN_TAG
+                - name: OPERATOR_NAME
+                  value: kubevirt-ssp-operator
+                image: REPLACE_IMAGE
+                imagePullPolicy: Always
+                name: kubevirt-ssp-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              serviceAccountName: kubevirt-ssp-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - KubeVirt
+  - Virtualization
+  - Template
+  - Performance
+  - VirtualMachine
+  - Node
+  - Labels
+  labels:
+    alm-owner-kubevirt: kubevirt-ssp-operator
+    operated-by: kubevirt-ssp-operator
+  links:
+  - name: KubeVirt
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/kubevirt
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: kubevirt-ssp-operator
+      operated-by: kubevirt-ssp-operator
+  version: PLACEHOLDER_CSV_VERSION


### PR DESCRIPTION
This PR adds the HCO's `csv-generator` logic to the ssp operator's container image. 

## Overview of Changes
* New `make csv-generator` make target generates a reusable pre-generated CSV file with placeholder values in the manifests/generated dir.
* `make container-build-operator` copies in both the placeholder CSV file and the new `csv-generator` script
* The operator's container can now be used to generate a corresponding CSV file using the `csv-generator` entry-point.

**Basic Example**
`docker run -it -rm --entrypoint=/usr/bin/csv-generator <operator image> --csv-version=1.1.1 --operator-image=someregistry/ssp-opereator:sometag --namespace=hco-namespace`

The HCO will be using this csv-generator entrypoint in the process of creating the aggregated HCO CSV that encompasses multiple component-level operators (like ssp).