### PR TITLE
roles: add role to deploy metric aggregation rules

### DIFF
--- a/deploy/crds/kubevirt_v1_metricsaggregation_cr.yaml
+++ b/deploy/crds/kubevirt_v1_metricsaggregation_cr.yaml
@@ -1,0 +1,6 @@
+apiVersion: kubevirt.io/v1
+kind: KubevirtMetricAggregation
+metadata:
+  name: kubevirt-metrics-aggregation
+spec:
+  version: v0.0.1

--- a/deploy/crds/kubevirt_v1_metricsaggregation_crd.yaml
+++ b/deploy/crds/kubevirt_v1_metricsaggregation_crd.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kubevirtmetricsaggregation.kubevirt.io
+  name: kubevirtmetricsaggregations.kubevirt.io
 spec:
   group: kubevirt.io
   names:

--- a/deploy/crds/kubevirt_v1_metricsaggregation_crd.yaml
+++ b/deploy/crds/kubevirt_v1_metricsaggregation_crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubevirtmetricsaggregation.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: KubevirtMetricsAggregation
+    listKind: KubevirtMetricsAggregationList
+    plural: kubevirtmetricsaggregations
+    singular: kubevirtmetricsaggregation
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+

--- a/functests/07-test-deploy-prometheus-rules.sh
+++ b/functests/07-test-deploy-prometheus-rules.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+SCRIPTPATH=$( dirname $(readlink -f $0) )
+source ${SCRIPTPATH}/testlib.sh
+
+RET=1
+TEST_NS="openshift"  # TODO: check this exists?
+
+{ oc get crds | grep -q prometheusrule; } || exit 99
+
+oc create -n ${TEST_NS} -f "${SCRIPTPATH}/aggregation-rules-unversioned-cr.yaml" || exit 2
+# TODO: SSP-operator needs to improve its feedback mechanism
+sleep 21s
+for idx in $( seq 1 30); do
+	NUM=$(oc get prometheusrules -n ${TEST_NS} -l "role=cnv-rules" -o json | jq ".items | length")
+	(( ${V} >= 1 )) && echo "prometheus rules found in ${TEST_NS}: ${NUM}"
+	if (( "${NUM}" > 0 )); then
+		(( ${V} >= 1 )) && echo "enough prometheus rules found in ${TEST_NS}"
+		RET=0
+		break
+	fi
+	sleep 3s
+done
+oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/aggregation-rules-unversioned-cr.yaml" || exit 2
+
+exit $RET

--- a/functests/aggregation-rules-unversioned-cr.yaml
+++ b/functests/aggregation-rules-unversioned-cr.yaml
@@ -1,0 +1,4 @@
+apiVersion: kubevirt.io/v1
+kind: KubevirtMetricsAggregation
+metadata:
+  name: kubevirt-metrics-aggregation

--- a/functests/test-runner.sh
+++ b/functests/test-runner.sh
@@ -22,7 +22,7 @@ done
 
 # we can run the real tests now
 RET=0
-for testscript in $( ls ??-test-*.sh); do
+for testscript in $( ls *-test-*.sh); do
 	testname=$(basename -- "$testscript")
 	testname="${testname%.*}"  # see http://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
 
@@ -33,10 +33,11 @@ for testscript in $( ls ??-test-*.sh); do
 		printf "* TESTCASE [%-64s] START\n" $testscript
 		./$testscript
 	fi
-	if [ "$?" == "0" ]; then
+	RC="$?"
+	if [ "$RC" == "0" ]; then
 		result="OK"
 	else
-		if [ "$?" == "99" ] ; then
+		if [ "$RC" == "99" ] ; then
 			result="SKIP"
 		else
 			result="FAILED"

--- a/hack/install-operator.sh
+++ b/hack/install-operator.sh
@@ -19,6 +19,7 @@ _curl() {
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_commontemplatesbundle_crd.yaml
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_nodelabellerbundle_crd.yaml
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_templatevalidator_crd.yaml
+oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_metricsaggregation_crd.yaml
 
 LAST_TAG=""
 if [ "${CI}" != "true" ] || [ "${TRAVIS}" != "true" ]; then

--- a/playbooks/metricsaggregation.yaml
+++ b/playbooks/metricsaggregation.yaml
@@ -1,0 +1,6 @@
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - _defaults.yml
+  roles:
+  - KubevirtMetricsAggregation

--- a/roles/KubevirtMetricsAggregation/defaults/main.yml
+++ b/roles/KubevirtMetricsAggregation/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for KubevirtMetricsAggregation

--- a/roles/KubevirtMetricsAggregation/handlers/main.yml
+++ b/roles/KubevirtMetricsAggregation/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for KubevirtMetricsAggregation

--- a/roles/KubevirtMetricsAggregation/meta/main.yml
+++ b/roles/KubevirtMetricsAggregation/meta/main.yml
@@ -1,0 +1,60 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 2.4
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/KubevirtMetricsAggregation/tasks/main.yml
+++ b/roles/KubevirtMetricsAggregation/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# tasks file for KubevirtMetricsAggregation
+- name: Install VMI count aggregation rule
+  k8s:
+    state: present
+    namespace: "{{ meta.namespace }}"
+    definition: "{{ item | from_yaml }}"
+  with_items: "{{ lookup('template', 'aggregation-rule-vmi-count.yaml.j2').split('\n---\n') | select('search', '(^|\n)[^#]') |list }}"
+

--- a/roles/KubevirtMetricsAggregation/templates/aggregation-rule-vmi-count.yaml.j2
+++ b/roles/KubevirtMetricsAggregation/templates/aggregation-rule-vmi-count.yaml.j2
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: cnv-rules
+  name: prometheus-k8s-rules-cnv
+  namespace: "{{ meta.namespace }}"
+spec:
+  groups:
+  - name: cnv.rules
+    rules:
+    - expr: |
+        sum(kubevirt_vmi_phase_count{phase="running"}) by (node)
+      record: cnv:vmi_status_running:count

--- a/roles/KubevirtMetricsAggregation/tests/inventory
+++ b/roles/KubevirtMetricsAggregation/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/KubevirtMetricsAggregation/tests/test.yml
+++ b/roles/KubevirtMetricsAggregation/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - KubevirtMetricsAggregation

--- a/roles/KubevirtMetricsAggregation/vars/main.yml
+++ b/roles/KubevirtMetricsAggregation/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for KubevirtMetricsAggregation

--- a/watches.yaml
+++ b/watches.yaml
@@ -11,3 +11,7 @@
   group: kubevirt.io
   kind: KubevirtNodeLabellerBundle
   playbook: /opt/ansible/kubevirtnodelabeller.yaml
+- version: v1
+  group: kubevirt.io
+  kind: KubevirtMetricsAggregation
+  playbook: /opt/ansible/metricsaggregation.yaml


### PR DESCRIPTION
Using PrometheusRules to configure the aggregation rules,
we can create the metrics CNV wants to consume out of the
metrics that kubevirt provides out of the box.

Signed-off-by: Francesco Romani <fromani@redhat.com>