### PR TITLE
validator: use consistent validator versions

### DIFF
--- a/_defaults.yml
+++ b/_defaults.yml
@@ -8,7 +8,7 @@
 #
 # validator_namespace: myproject
 # validator_image: registry.example.com/mine/kubevirt-template-validator
-# validator_tag: v0.4.8
+# validator_tag: v0.6.1
 # templates_version: v0.6.0
 ---
 #node-labeller

--- a/deploy/crds/kubevirt_v1_templatevalidator_cr.yaml
+++ b/deploy/crds/kubevirt_v1_templatevalidator_cr.yaml
@@ -4,4 +4,4 @@ metadata:
   name: kubevirt-template-validator
   namespace: kubevirt
 spec:
-  version: v0.4.8
+  version: v0.6.1

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -7,7 +7,7 @@ import "fmt"
 const (
 	KubevirtCommonTemplates   string = "0.6.0"
 	KubevirtNodeLabeller      string = "0.0.5"
-	KubevirtTemplateValidator string = "0.4.8"
+	KubevirtTemplateValidator string = "0.6.1"
 )
 
 // TagForVersion converts the given version in a suitable tag

--- a/roles/KubevirtTemplateValidator/defaults/main.yml
+++ b/roles/KubevirtTemplateValidator/defaults/main.yml
@@ -3,4 +3,4 @@
 wait: true
 validator_image: kubevirt-template-validator
 # this comes from the CR, we must diverge from validator_$SOMETHING standard naming
-version: "{{ validator_tag |default('v0.4.8') }}"
+version: "{{ validator_tag |default('v0.6.1') }}"


### PR DESCRIPTION
We have plenty of duplicates places on which we set
the default versions. We need to simplify and clean this mess,
but until we do, we need to keep the default consistent to
avoid even nastier surprises.

Signed-off-by: Francesco Romani <fromani@redhat.com>