### PR TITLE
manifests: fix operator image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ manifests-cleanup:
 	rm -rf _out
 
 manifests: csv-generator manifests-cleanup manifests-prepare operator-sdk
-	./build/make-manifests.sh ${IMAGE_TAG}
+	./hack/make-manifests.sh ${IMAGE_TAG}
 	./hack/release-manifests.sh ${IMAGE_TAG}
 
 release: manifests container-build container-release

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1,3 +1,8 @@
+# WARNING! this manifest is not meant for direct consumption.
+# you are supposed to deploy the operator either
+# - through the HyperConverged Operator
+# - using the released manifests, see github
+# - using hack/install-operator.sh
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,7 +20,6 @@ spec:
       serviceAccountName: kubevirt-ssp-operator
       containers:
         - name: kubevirt-ssp-operator
-          #FIXME Replace this with the built image name
           image: REPLACE_IMAGE
           ports:
           - containerPort: 60000

--- a/hack/_common.sh
+++ b/hack/_common.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+
+_curl() {
+	# this dupes the baseline "curl" command line, but is simpler
+	# wrt shell quoting/expansion.
+	if [ -n "${GITHUB_TOKEN}" ]; then
+		curl -H "Authorization: token ${GITHUB_TOKEN}" $@
+	else
+		curl $@
+	fi
+}
+

--- a/hack/get-operator-tag.sh
+++ b/hack/get-operator-tag.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+SELF=$( realpath $0 )
+BASEPATH=$( dirname $SELF )
+
+source ${BASEPATH}/_common.sh
+
+if [ -n "${TRAVIS_TAG}" ]; then
+	# travis build, generating a new tag
+	echo "${TRAVIS_TAG}"
+else
+	# refreshing manifests, getting the last stable tag
+	_curl -s 'https://api.github.com/repos/MarSik/kubevirt-ssp-operator/tags' | jq -r '.[].name' | sort -r | head -1
+fi

--- a/hack/install-operator.sh
+++ b/hack/install-operator.sh
@@ -6,21 +6,14 @@ BASEPATH=$( dirname $SELF )
 
 NAMESPACE=${1:-kubevirt}
 
-_curl() {
-	# this dupes the baseline "curl" command line, but is simpler
-	# wrt shell quoting/expansion.
-	if [ -n "${GITHUB_TOKEN}" ]; then
-		curl -H "Authorization: token ${GITHUB_TOKEN}" $@
-	else
-		curl $@
-	fi
-}
+source ${BASEPATH}/_common.sh
 
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_commontemplatesbundle_crd.yaml
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_nodelabellerbundle_crd.yaml
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_templatevalidator_crd.yaml
 oc create -f ${BASEPATH}/../deploy/crds/kubevirt_v1_metricsaggregation_crd.yaml
 
+# we need to do this before to deploy any manifest, so if this fails we bail out as soon as possible.
 LAST_TAG=""
 if [ "${CI}" != "true" ] || [ "${TRAVIS}" != "true" ]; then
 	# TODO: consume releases, not tags

--- a/hack/make-manifests.sh
+++ b/hack/make-manifests.sh
@@ -43,7 +43,7 @@ for MF in deploy/service_account.yaml deploy/role.yaml deploy/role_binding.yaml 
 done
 ) > ${CLUSTER_VERSIONED_DIR}/kubevirt-ssp-operator.yaml
 
-./build/csv-generator.sh --csv-version=${VERSION} --namespace=placeholder --operator-image=REPLACE_IMAGE > ${MANIFESTS_VERSIONED_DIR}/kubevirt-ssp-operator.${TAG}.clusterserviceversion.yaml
+${BASEPATH}/..build/csv-generator.sh --csv-version=${VERSION} --namespace=placeholder --operator-image=REPLACE_IMAGE > ${MANIFESTS_VERSIONED_DIR}/kubevirt-ssp-operator.${TAG}.clusterserviceversion.yaml
 
 # caution: operator-courier (as in 5a4852c) wants *one* entity per yaml file (e.g. it does NOT use safe_load_all)
 for CRD in $( ls deploy/crds/kubevirt_*crd.yaml ); do


### PR DESCRIPTION
We need to fix various flows on which we build manifests:
- the release flow (entry point: make-manifests.sh)
- the install flow (entry point: install-operator.sh)

In any case: we should never leave the placeholder `REPLACE_IMAGE` in
the manifests fail, and we should never use floating tags ('devel',
'latest'...)  outside the travis *testing* stage.

Signed-off-by: Francesco Romani <fromani@redhat.com>