### PR TITLE
Condition statuses

### DIFF
--- a/playbooks/commontemplatesbundle.yaml
+++ b/playbooks/commontemplatesbundle.yaml
@@ -1,5 +1,4 @@
 - hosts: localhost
-  gather_facts: no
   vars_files:
     - _defaults.yml
   roles:

--- a/playbooks/kubevirtnodelabeller.yaml
+++ b/playbooks/kubevirtnodelabeller.yaml
@@ -1,5 +1,4 @@
 - hosts: localhost
-  gather_facts: no
   vars_files:
     - _defaults.yml
   roles:

--- a/playbooks/templatevalidator.yaml
+++ b/playbooks/templatevalidator.yaml
@@ -1,5 +1,4 @@
 - hosts: localhost
-  gather_facts: no
   vars_files:
     - _defaults.yml
   roles:

--- a/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
@@ -1,9 +1,150 @@
 ---
 # tasks file for KubevirtCommonTemplatesBundle
+- name: "Get all templates"
+  set_fact:
+    deployed_templates_before: "{{ lookup('k8s', api_version='template.openshift.io/v1', kind='template') }}"
+
 - name: Install VM templates
   k8s:
     state: present
     namespace: "{{ meta.namespace }}"
     definition: "{{ item | from_yaml }}"
   with_items: "{{ lookup('file', 'common-templates-'+ version +'.yaml').split('\n---\n') | select('search', '(^|\n)[^#]') |list }}"
+  register: ct_status
 
+- name: "Get all templates"
+  set_fact:
+    deployed_templates_after: "{{ lookup('k8s', api_version=ct_status.results[0].result.apiVersion, kind='template') }}"
+
+- name: "Get common-templates-cr"
+  k8s:
+    state: present
+    definition: "{{ lookup('k8s', kind='KubevirtCommonTemplatesBundle', namespace=meta.namespace, resource_name='kubevirt-common-template-bundle') | from_yaml }}"
+  register: ct_cr
+
+- name: "Get latest progressive condition"
+  vars:
+    query: "result.status.conditions[?type=='Progressing'].{status: status, lastTransitionTime: lastTransitionTime}"
+    progressing_statuses: "{{ct_cr|json_query(query)}}"
+  set_fact:
+    last_progressing_status: "{{false if progressing_statuses|length == 0 else progressing_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+
+- name: Set progressing condition
+  when: (not last_progressing_status) and (deployed_templates_before|length != deployed_templates_after|length)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtCommonTemplatesBundle
+    name: kubevirt-common-template-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Progressing
+      status: "True"
+      reason: "deploying"
+      message: "Deploying templates."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: Unset progressing condition
+  when: last_progressing_status and (deployed_templates_before|length == deployed_templates_after|length)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtCommonTemplatesBundle
+    name: kubevirt-common-template-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Progressing
+      status: "False"
+      reason: "deploying"
+      message: "Common templates deployed."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: "Get common-templates-cr"
+  k8s:
+    state: present
+    definition: "{{ lookup('k8s', kind='KubevirtCommonTemplatesBundle', namespace=meta.namespace, resource_name='kubevirt-common-template-bundle') | from_yaml }}"
+  register: ct_cr
+
+- name: "Get latest available condition"
+  vars:
+    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
+    available_statuses: "{{ct_cr|json_query(query)}}"
+  set_fact:
+    last_available_status: "{{false if available_statuses|length == 0 else available_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+
+- name: Set available condition
+  when: (not last_available_status) and (deployed_templates_before|length == deployed_templates_after|length)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtCommonTemplatesBundle
+    name: kubevirt-common-template-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Available
+      status: "True"
+      reason: "deployed"
+      message: "Common templates deployed."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: Unset available condition
+  when: last_available_status and (deployed_templates_before|length != deployed_templates_after|length)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtCommonTemplatesBundle
+    name: kubevirt-common-template-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Available
+      status: "False"
+      reason: "deployed"
+      message: "Common templates are missing some templates."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+
+- name: "Get common-templates-cr"
+  k8s:
+    state: present
+    definition: "{{ lookup('k8s', kind='KubevirtCommonTemplatesBundle', namespace=meta.namespace, resource_name='kubevirt-common-template-bundle') | from_yaml }}"
+  register: ct_cr
+
+- name: "Get any available condition"
+  vars:
+    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
+    available_statuses: "{{ct_cr|json_query(query)}}"
+  set_fact:
+    has_available_status: "{{false if available_statuses|length == 0 else true}}"
+
+# degraded condition will be set only if, nl was sometime available (it doesn't matter if condition was True or False), 
+# but now doesn't have enough pods
+- name: Set degraded condition
+  when: has_available_status and (deployed_templates_before|length != deployed_templates_after|length)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtCommonTemplatesBundle
+    name: kubevirt-common-template-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Degraded
+      status: "True"
+      reason: "degraded"
+      message: "Common templates are degraded."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: "Get latest degraded condition"
+  vars:
+    query: "result.status.conditions[?type=='Degraded'].{status: status, lastTransitionTime: lastTransitionTime}"
+    degraded_statuses: "{{ct_cr|json_query(query)}}"
+  set_fact:
+    last_degraded_status: "{{false if degraded_statuses|length == 0 else degraded_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+
+- name: Set degraded condition
+  when: last_degraded_status and (deployed_templates_before|length == deployed_templates_after|length)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtCommonTemplatesBundle
+    name: kubevirt-common-template-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Degraded
+      status: "False"
+      reason: "degraded"
+      message: "Common templates deployed."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"

--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -11,19 +11,19 @@
     definition: "{{ lookup('template', 'kubevirt-node-labeller-ds.yaml.j2') | from_yaml }}"
   register: nl
 
-- name: "refresh node-labeller var"
+- name: "Refresh node-labeller var"
   k8s:
     state: present
     definition: "{{ lookup('k8s', kind=nl.result.kind, namespace=nl.result.metadata.namespace, resource_name=nl.result.metadata.name) | from_yaml }}"
   register: nl_status
 
-- name: "get node-labeller-cr"
+- name: "Get node-labeller-cr"
   k8s:
     state: present
     definition: "{{ lookup('k8s', kind='KubevirtNodeLabellerBundle', namespace=meta.namespace, resource_name='kubevirt-node-labeller-bundle') | from_yaml }}"
   register: nl_cr
 
-- name: "get latest progressive condition"
+- name: "Get latest progressive condition"
   vars:
     query: "result.status.conditions[?type=='Progressing'].{status: status, lastTransitionTime: lastTransitionTime}"
     progressing_statuses: "{{nl_cr|json_query(query)}}"
@@ -42,7 +42,7 @@
     - type: Progressing
       status: "True"
       reason: "deploying"
-      message: "deploying node-labeller"
+      message: "Deploying node-labeller."
       lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
 
 - name: Unset progressing condition
@@ -56,16 +56,16 @@
     - type: Progressing
       status: "False"
       reason: "deploying"
-      message: "node-labeller has successfully progressed."
+      message: "Node-labeller has successfully progressed."
       lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
 
-- name: "get node-labeller-cr"
+- name: "Get node-labeller-cr"
   k8s:
     state: present
     definition: "{{ lookup('k8s', kind='KubevirtNodeLabellerBundle', namespace=meta.namespace, resource_name='kubevirt-node-labeller-bundle') | from_yaml }}"
   register: nl_cr
 
-- name: "get latest available condition"
+- name: "Get latest available condition"
   vars:
     query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
     available_statuses: "{{nl_cr|json_query(query)}}"
@@ -83,7 +83,7 @@
     - type: Available
       status: "True"
       reason: "running"
-      message: "node-labeller has required number of pods"
+      message: "Node-labeller has required number of pods."
       lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
 
 - name: Unset available condition
@@ -96,6 +96,56 @@
     conditions:
     - type: Available
       status: "False"
-      reason: "running"
-      message: "node-labeller hasn't got required number of pods"
+      reason: "failed"
+      message: "Node-labeller hasn't got required number of pods."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: "Get node-labeller-cr"
+  k8s:
+    state: present
+    definition: "{{ lookup('k8s', kind='KubevirtNodeLabellerBundle', namespace=meta.namespace, resource_name='kubevirt-node-labeller-bundle') | from_yaml }}"
+  register: nl_cr
+
+- name: "Get any available condition"
+  vars:
+    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
+    available_statuses: "{{nl_cr|json_query(query)}}"
+  set_fact:
+    has_available_status: "{{false if available_statuses|length == 0 else true}}"
+
+# degraded condition will be set only if, nl was sometime available (it doesn't matter if condition was True or False), 
+# but now doesn't have enough pods
+- name: Set degraded condition
+  when: has_available_status and (nl_status.result.status.currentNumberScheduled != nl_status.result.status.numberReady)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtNodeLabellerBundle
+    name: kubevirt-node-labeller-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Degraded
+      status: "True"
+      reason: "degraded"
+      message: "Node-labeller is degraded."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: "Get latest degraded condition"
+  vars:
+    query: "result.status.conditions[?type=='Degraded'].{status: status, lastTransitionTime: lastTransitionTime}"
+    degraded_statuses: "{{nl_cr|json_query(query)}}"
+  set_fact:
+    last_degraded_status: "{{false if degraded_statuses|length == 0 else degraded_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+
+- name: Unset degraded condition
+  when: last_degraded_status and (nl_status.result.status.currentNumberScheduled == nl_status.result.status.numberReady)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtNodeLabellerBundle
+    name: kubevirt-node-labeller-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Degraded
+      status: "False"
+      reason: "degraded"
+      message: "Node-labeller has required number of pods."
       lastTransitionTime: "{{ ansible_date_time.iso8601 }}"

--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -4,15 +4,98 @@
     state: present
     definition: "{{ item | from_yaml }}"
   with_items: "{{ lookup('template', 'kubevirt-node-labeller-roles.yaml.j2').split('\n---\n') | select('search', '(^|\n)[^#]') | list }}"
+
 - name: Create the node labeller daemon set
   k8s:
     state: present
     definition: "{{ lookup('template', 'kubevirt-node-labeller-ds.yaml.j2') | from_yaml }}"
   register: nl
-- name: "Wait for the node-labeller to start"
+
+- name: "refresh node-labeller var"
+  k8s:
+    state: present
+    definition: "{{ lookup('k8s', kind=nl.result.kind, namespace=nl.result.metadata.namespace, resource_name=nl.result.metadata.name) | from_yaml }}"
+  register: nl_status
+
+- name: "get node-labeller-cr"
+  k8s:
+    state: present
+    definition: "{{ lookup('k8s', kind='KubevirtNodeLabellerBundle', namespace=meta.namespace, resource_name='kubevirt-node-labeller-bundle') | from_yaml }}"
+  register: nl_cr
+
+- name: "get latest progressive condition"
+  vars:
+    query: "result.status.conditions[?type=='Progressing'].{status: status, lastTransitionTime: lastTransitionTime}"
+    progressing_statuses: "{{nl_cr|json_query(query)}}"
   set_fact:
-    nl_status: "{{ lookup('k8s', kind=nl.result.kind, namespace=nl.result.metadata.namespace, resource_name=nl.result.metadata.name) | from_yaml }}"
-  retries: 300
-  delay: 10
-  until: nl_status.status.currentNumberScheduled == nl_status.status.numberReady |default(false)
-  when: not wait
+    last_progressing_status: "{{false if progressing_statuses|length == 0 else progressing_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+
+
+- name: Set progressing condition
+  when: (not last_progressing_status) and (nl_status.result.status.currentNumberScheduled != nl_status.result.status.numberReady)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtNodeLabellerBundle
+    name: kubevirt-node-labeller-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Progressing
+      status: "True"
+      reason: "deploying"
+      message: "deploying node-labeller"
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: Unset progressing condition
+  when: last_progressing_status and nl_status.result.status.currentNumberScheduled == nl_status.result.status.numberReady
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtNodeLabellerBundle
+    name: kubevirt-node-labeller-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Progressing
+      status: "False"
+      reason: "deploying"
+      message: "node-labeller has successfully progressed."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: "get node-labeller-cr"
+  k8s:
+    state: present
+    definition: "{{ lookup('k8s', kind='KubevirtNodeLabellerBundle', namespace=meta.namespace, resource_name='kubevirt-node-labeller-bundle') | from_yaml }}"
+  register: nl_cr
+
+- name: "get latest available condition"
+  vars:
+    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
+    available_statuses: "{{nl_cr|json_query(query)}}"
+  set_fact:
+    last_available_status: "{{false if available_statuses|length == 0 else available_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+
+- name: Set available condition
+  when: (not last_available_status) and (nl_status.result.status.currentNumberScheduled == nl_status.result.status.numberReady)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtNodeLabellerBundle
+    name: kubevirt-node-labeller-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Available
+      status: "True"
+      reason: "running"
+      message: "node-labeller has required number of pods"
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: Unset available condition
+  when: last_available_status and (nl_status.result.status.currentNumberScheduled != nl_status.result.status.numberReady)
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtNodeLabellerBundle
+    name: kubevirt-node-labeller-bundle
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Available
+      status: "False"
+      reason: "running"
+      message: "node-labeller hasn't got required number of pods"
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -25,22 +25,23 @@
   set_fact:
     tv_status: "{{ lookup('k8s', kind=tv.results[3].result.kind, namespace=tv.results[3].result.metadata.namespace, resource_name=tv.results[3].result.metadata.name) | from_yaml }}"
 
-
-- name: "get template-validator-cr"
+- name: "Get template-validator-cr"
   k8s:
     state: present
-    definition: "{{ lookup('k8s', kind='KubevirtTemplateValidator', namespace= 'kubevirt', resource_name='kubevirt-template-validator') | from_yaml }}"
+    definition: "{{ lookup('k8s', kind='KubevirtTemplateValidator', namespace=meta.namespace, resource_name='kubevirt-template-validator') | from_yaml }}"
   register: tv_cr
 
-- name: "get latest progressive condition"
+- name: "Get latest progressive condition"
   vars:
     query: "result.status.conditions[?type=='Progressing'].{status: status, lastTransitionTime: lastTransitionTime}"
     progressing_statuses: "{{tv_cr|json_query(query)}}"
   set_fact:
     tv_last_progressing_status: "{{false if progressing_statuses|length == 0 else progressing_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
 
+# defaults in this ansible code are here because at the start of deployment, there is a chance 
+# there will be no attributes like availableReplicas and readyReplicas
 - name: Set progressing condition
-  when: (not tv_last_progressing_status) and (tv_status.status.availableReplicas|default(0)  != tv_status.status.readyReplicas|default(2))
+  when: (not tv_last_progressing_status) and (tv_status.status.availableReplicas|default(0) != tv_status.status.readyReplicas|default(2))
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtTemplateValidator
@@ -67,13 +68,13 @@
       message: "Template-validator has successfully progressed."
       lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
 
-- name: "get node-labeller-cr"
+- name: "Get template-validator-cr"
   k8s:
     state: present
-    definition: "{{ lookup('k8s', kind='KubevirtTemplateValidator', namespace= 'kubevirt', resource_name='kubevirt-template-validator') | from_yaml }}"
+    definition: "{{ lookup('k8s', kind='KubevirtTemplateValidator', namespace=meta.namespace, resource_name='kubevirt-template-validator') | from_yaml }}"
   register: tv_cr
 
-- name: "get latest available condition"
+- name: "Get latest available condition"
   vars:
     query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
     available_statuses: "{{tv_cr|json_query(query)}}"
@@ -106,4 +107,54 @@
       status: "False"
       reason: "running"
       message: "Template-validator hasn't got required number of pods."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: "Get template-validator-cr"
+  k8s:
+    state: present
+    definition: "{{ lookup('k8s', kind='KubevirtTemplateValidator', namespace=meta.namespace, resource_name='kubevirt-template-validator') | from_yaml }}"
+  register: tv_cr
+
+- name: "Get any available condition"
+  vars:
+    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
+    available_statuses: "{{tv_cr|json_query(query)}}"
+  set_fact:
+    has_available_status: "{{false if available_statuses|length == 0 else true}}"
+
+# degraded condition will be set only if, tv was sometime available (it doesn't matter if condition was True or False), 
+# but now doesn't have enough pods
+- name: Set degraded condition
+  when: has_available_status and (tv_status.status.availableReplicas|default(0) != tv_status.status.readyReplicas|default(2))
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtTemplateValidator
+    name: kubevirt-template-validator
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Degraded
+      status: "True"
+      reason: "degraded"
+      message: "Template-validator is degraded."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: "Get latest degraded condition"
+  vars:
+    query: "result.status.conditions[?type=='Degraded'].{status: status, lastTransitionTime: lastTransitionTime}"
+    degraded_statuses: "{{tv_cr|json_query(query)}}"
+  set_fact:
+    last_degraded_status: "{{false if degraded_statuses|length == 0 else degraded_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+
+- name: Unset degraded condition
+  when: last_degraded_status and (tv_status.status.availableReplicas|default(0) == tv_status.status.readyReplicas|default(2))
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtTemplateValidator
+    name: kubevirt-template-validator
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Degraded
+      status: "False"
+      reason: "degraded"
+      message: "Template-validator has required number of pods."
       lastTransitionTime: "{{ ansible_date_time.iso8601 }}"

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -20,10 +20,90 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'webhook.yaml.j2') | from_yaml }}"
-- name: Wait for the template-validator to start
+  
+- name: Refresh template-validator var
   set_fact:
-    tv_status: "{{ lookup('k8s', kind=tv.result.kind, namespace=tv.result.metadata.namespace, resource_name=tv.result.metadata.name) | from_yaml }}"
-  retries: 300
-  delay: 10
-  until: tv_status.status.currentNumberScheduled == tv_status.status.numberReady |default(false)
-  when: not wait
+    tv_status: "{{ lookup('k8s', kind=tv.results[3].result.kind, namespace=tv.results[3].result.metadata.namespace, resource_name=tv.results[3].result.metadata.name) | from_yaml }}"
+
+
+- name: "get template-validator-cr"
+  k8s:
+    state: present
+    definition: "{{ lookup('k8s', kind='KubevirtTemplateValidator', namespace= 'kubevirt', resource_name='kubevirt-template-validator') | from_yaml }}"
+  register: tv_cr
+
+- name: "get latest progressive condition"
+  vars:
+    query: "result.status.conditions[?type=='Progressing'].{status: status, lastTransitionTime: lastTransitionTime}"
+    progressing_statuses: "{{tv_cr|json_query(query)}}"
+  set_fact:
+    tv_last_progressing_status: "{{false if progressing_statuses|length == 0 else progressing_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+
+- name: Set progressing condition
+  when: (not tv_last_progressing_status) and (tv_status.status.availableReplicas|default(0)  != tv_status.status.readyReplicas|default(2))
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtTemplateValidator
+    name: kubevirt-template-validator
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Progressing
+      status: "True"
+      reason: "deploying"
+      message: "Template-validator is progressing."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: Unset progressing condition
+  when: tv_last_progressing_status and (tv_status.status.availableReplicas|default(0) == tv_status.status.readyReplicas|default(2))
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtTemplateValidator
+    name: kubevirt-template-validator
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Progressing
+      status: "False"
+      reason: "deploying"
+      message: "Template-validator has successfully progressed."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: "get node-labeller-cr"
+  k8s:
+    state: present
+    definition: "{{ lookup('k8s', kind='KubevirtTemplateValidator', namespace= 'kubevirt', resource_name='kubevirt-template-validator') | from_yaml }}"
+  register: tv_cr
+
+- name: "get latest available condition"
+  vars:
+    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
+    available_statuses: "{{tv_cr|json_query(query)}}"
+  set_fact:
+    tv_last_available_status: "{{false if available_statuses|length == 0 else available_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+
+- name: Set available condition
+  when: (not tv_last_available_status) and (tv_status.status.availableReplicas|default(0) == tv_status.status.readyReplicas|default(2))
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtTemplateValidator
+    name: kubevirt-template-validator
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Available
+      status: "True"
+      reason: "running"
+      message: "Template-validator is running."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+
+- name: Unset available condition
+  when: tv_last_available_status and (tv_status.status.availableReplicas|default(0) != tv_status.status.readyReplicas|default(2))
+  k8s_status:
+    api_version: kubevirt.io/v1
+    kind: KubevirtTemplateValidator
+    name: kubevirt-template-validator
+    namespace: "{{ meta.namespace }}"
+    conditions:
+    - type: Available
+      status: "False"
+      reason: "running"
+      message: "Template-validator hasn't got required number of pods."
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"


### PR DESCRIPTION
This PR adds condition statuses to node-labeller, template-validator. There are 3 types of conditions: progressing, available, degraded (meanings of these conditions can be found here: https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/docs/conditions.md#condition-matrix)
These conditions pose status of each component of ssp operator.
/cc @MarSik, @fromanirh 