### PR TITLE
bump node-labeller and friends versions

### DIFF
--- a/_defaults.yml
+++ b/_defaults.yml
@@ -19,4 +19,4 @@ kubevirt_cpu_nfd_plugin_tag: "{{ lookup('env','CPU_PLUGIN_TAG')| default('v0.1.1
 virt_launcher_tag: "{{ lookup('env','VIRT_LAUNCHER_TAG')| default('v0.19.0', true) }}"
 
 #validator
-validator_tag: "{{ lookup('env','VALIDATOR_TAG')| default('v0.6.1', true) }}"
+validator_tag: "{{ lookup('env','VALIDATOR_TAG')| default('v0.6.2', true) }}"

--- a/_defaults.yml
+++ b/_defaults.yml
@@ -13,10 +13,10 @@
 
 ---
 #node-labeller
-kubevirt_node_labeller_tag: "{{ lookup('env','NODE_LABELLER_TAG')| default('v0.1.0', true) }}"
-kvm_info_nfd_plugin_tag: "{{ lookup('env','KVM_INFO_TAG')| default('v0.5.7', true) }}"
-kubevirt_cpu_nfd_plugin_tag: "{{ lookup('env','CPU_PLUGIN_TAG')| default('v0.1.0', true) }}"
-virt_launcher_tag: "{{ lookup('env','VIRT_LAUNCHER_TAG')| default('v0.18.0', true) }}"
+kubevirt_node_labeller_tag: "{{ lookup('env','NODE_LABELLER_TAG')| default('v0.1.1', true) }}"
+kvm_info_nfd_plugin_tag: "{{ lookup('env','KVM_INFO_TAG')| default('v0.5.8', true) }}"
+kubevirt_cpu_nfd_plugin_tag: "{{ lookup('env','CPU_PLUGIN_TAG')| default('v0.1.1', true) }}"
+virt_launcher_tag: "{{ lookup('env','VIRT_LAUNCHER_TAG')| default('v0.19.0', true) }}"
 
 #validator
 validator_tag: "{{ lookup('env','VALIDATOR_TAG')| default('v0.6.1', true) }}"

--- a/deploy/crds/kubevirt_v1_templatevalidator_cr.yaml
+++ b/deploy/crds/kubevirt_v1_templatevalidator_cr.yaml
@@ -4,4 +4,4 @@ metadata:
   name: kubevirt-template-validator
   namespace: kubevirt
 spec:
-  version: v0.6.1
+  version: v0.6.2

--- a/roles/KubevirtTemplateValidator/defaults/main.yml
+++ b/roles/KubevirtTemplateValidator/defaults/main.yml
@@ -3,4 +3,4 @@
 wait: true
 validator_image: kubevirt-template-validator
 # this comes from the CR, we must diverge from validator_$SOMETHING standard naming
-version: "{{ validator_tag |default('v0.6.1') }}"
+version: "{{ validator_tag |default('v0.6.2') }}"


### PR DESCRIPTION
This PR sets new versions for node-labeller, kvm-info plugin, cpu-model plugin, virt-launcher