### PR TITLE
CR conditions refactored

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,9 @@ COPY _defaults.yml ${HOME}/_defaults.yml
 COPY deploy/crds ${HOME}/deploy/crds
 COPY manifests/generated ${HOME}/manifests/generated
 COPY build/csv-generator.sh /usr/bin/csv-generator
-#original module k8s_status contains bug, which prevents ssp operator to correctly set conditions
+#original module k8s_status contains bugs, which prevents ssp operator to correctly set conditions
+#https://github.com/operator-framework/operator-sdk/pull/1820
+#https://github.com/operator-framework/operator-sdk/pull/1845
 COPY build/k8s_status.py /usr/share/ansible/openshift
 
 COPY build/preprocess_template.py ${HOME}/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,6 +10,8 @@ COPY _defaults.yml ${HOME}/_defaults.yml
 COPY deploy/crds ${HOME}/deploy/crds
 COPY manifests/generated ${HOME}/manifests/generated
 COPY build/csv-generator.sh /usr/bin/csv-generator
+#original module k8s_status contains bug, which prevents ssp operator to correctly set conditions
+COPY build/k8s_status.py /usr/share/ansible/openshift
 
 COPY build/preprocess_template.py ${HOME}/
 COPY patch.yaml ${HOME}/

--- a/build/k8s_status.py
+++ b/build/k8s_status.py
@@ -1,0 +1,373 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+#################################################################################
+# This file is here, because original k8s_status contains bug, which prevents ssp
+# operator to properly sets CR conditions. PR with fix is already posted 
+# https://github.com/operator-framework/operator-sdk/pull/1820
+# We have to wait until it will be merged and new version with fix released.
+#################################################################################
+
+from __future__ import absolute_import, division, print_function
+
+import re
+import copy
+
+from ansible.module_utils.k8s.common import AUTH_ARG_SPEC, COMMON_ARG_SPEC, KubernetesAnsibleModule
+
+try:
+    from openshift.dynamic.exceptions import DynamicApiError
+except ImportError as exc:
+    class KubernetesException(Exception):
+        pass
+
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+module: k8s_status
+short_description: Update the status for a Kubernetes API resource
+version_added: "2.7"
+author: "Fabian von Feilitzsch (@fabianvf)"
+description:
+  - Sets the status field on a Kubernetes API resource. Only should be used if you are using Ansible to
+    implement a controller for the resource being modified.
+options:
+  status:
+    type: dict
+    description:
+    - A object containing `key: value` pairs that will be set on the status object of the specified resource.
+    - One of I(status) or I(conditions) is required.
+  conditions:
+    type: list
+    description:
+    - A list of condition objects that will be set on the status.conditions field of the specified resource.
+    - Unless I(force) is C(true) the specified conditions will be merged with the conditions already set on the status field of the specified resource.
+    - Each element in the list will be validated according to the conventions specified in the
+      [Kubernetes API conventions document](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status).
+    - 'The fields supported for each condition are:
+      `type` (required),
+      `status` (required, one of "True", "False", "Unknown"),
+      `reason` (single CamelCase word),
+      `message`,
+      `lastHeartbeatTime` (RFC3339 datetime string), and
+      `lastTransitionTime` (RFC3339 datetime string).'
+    - One of I(status) or I(conditions) is required.'
+  api_version:
+    description:
+    - Use to specify the API version. Use in conjunction with I(kind), I(name), and I(namespace) to identify a
+      specific object.
+    required: yes
+    aliases:
+    - api
+    - version
+  kind:
+    description:
+    - Use to specify an object model. Use in conjunction with I(api_version), I(name), and I(namespace) to identify a
+      specific object.
+    required: yes
+  name:
+    description:
+    - Use to specify an object name. Use in conjunction with I(api_version), I(kind) and I(namespace) to identify a
+      specific object.
+    required: yes
+  namespace:
+    description:
+    - Use to specify an object namespace. Use in conjunction with I(api_version), I(kind), and I(name)
+      to identify a specific object.
+  force:
+    description:
+    - If set to C(True), the status will be set using `PUT` rather than `PATCH`, replacing the full status object.
+    default: false
+    type: bool
+  host:
+    description:
+    - Provide a URL for accessing the API. Can also be specified via K8S_AUTH_HOST environment variable.
+  api_key:
+    description:
+    - Token used to authenticate with the API. Can also be specified via K8S_AUTH_API_KEY environment variable.
+  kubeconfig:
+    description:
+    - Path to an instance Kubernetes config file. If not provided, and no other connection
+      options are provided, the openshift client will attempt to load the default
+      configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG environment
+      variable.
+  context:
+    description:
+    - The name of a context found in the config file. Can also be specified via K8S_AUTH_CONTEXT environment variable.
+  username:
+    description:
+    - Provide a username for authenticating with the API. Can also be specified via K8S_AUTH_USERNAME environment
+      variable.
+  password:
+    description:
+    - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD environment
+      variable.
+  cert_file:
+    description:
+    - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE environment
+      variable.
+  key_file:
+    description:
+    - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE environment
+      variable.
+  ssl_ca_cert:
+    description:
+    - Path to a CA certificate used to authenticate with the API. Can also be specified via K8S_AUTH_SSL_CA_CERT
+      environment variable.
+  verify_ssl:
+    description:
+    - "Whether or not to verify the API server's SSL certificates. Can also be specified via K8S_AUTH_VERIFY_SSL
+      environment variable."
+    type: bool
+requirements:
+    - "python >= 2.7"
+    - "openshift >= 0.8.1"
+    - "PyYAML >= 3.11"
+'''
+
+EXAMPLES = '''
+- name: Set custom status fields on TestCR
+  k8s_status:
+    api_version: apps.example.com/v1alpha1
+    kind: TestCR
+    name: my-test
+    namespace: testing
+    status:
+        hello: world
+        custom: entries
+- name: Update the standard condition of an Ansible Operator
+  k8s_status:
+    api_version: apps.example.com/v1alpha1
+    kind: TestCR
+    name: my-test
+    namespace: testing
+    conditions:
+    - type: Running
+      status: "True"
+      reason: MigrationStarted
+      message: "Migration from v2 to v3 has begun"
+      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+- name: |
+    Create custom conditions. WARNING: The default Ansible Operator status management
+    will never overwrite custom conditions, so they will persist indefinitely. If you
+    want the values to change or be removed, you will need to clean them up manually.
+  k8s_status:
+    conditions:
+    - type: Available
+      status: "False"
+      reason: PingFailed
+      message: "The service did not respond to a ping"
+'''
+
+RETURN = '''
+result:
+  description:
+  - If a change was made, will return the patched object, otherwise returns the instance object.
+  returned: success
+  type: complex
+  contains:
+     api_version:
+       description: The versioned schema of this representation of an object.
+       returned: success
+       type: str
+     kind:
+       description: Represents the REST resource this object represents.
+       returned: success
+       type: str
+     metadata:
+       description: Standard object metadata. Includes name, namespace, annotations, labels, etc.
+       returned: success
+       type: complex
+     spec:
+       description: Specific attributes of the object. Will vary based on the I(api_version) and I(kind).
+       returned: success
+       type: complex
+     status:
+       description: Current status details for the object.
+       returned: success
+       type: complex
+'''
+
+
+def condition_array(conditions):
+
+    VALID_KEYS = ['type', 'status', 'reason', 'message', 'lastHeartbeatTime', 'lastTransitionTime']
+    REQUIRED = ['type', 'status']
+    CAMEL_CASE = re.compile(r'^(?:[A-Z]*[a-z]*)+$')
+    RFC3339_datetime = re.compile(r'^\d{4}-\d\d-\d\dT\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)$')
+
+    def validate_condition(condition):
+        if not isinstance(condition, dict):
+            raise ValueError('`conditions` must be a list of objects')
+        if isinstance(condition.get('status'), bool):
+            condition['status'] = 'True' if condition['status'] else 'False'
+
+        for key in condition.keys():
+            if key not in VALID_KEYS:
+                raise ValueError('{} is not a valid field for a condition, accepted fields are {}'.format(key, VALID_KEYS))
+        for key in REQUIRED:
+            if not condition.get(key):
+                raise ValueError('Condition `{}` must be set'.format(key))
+
+        if condition['status'] not in ['True', 'False', 'Unknown']:
+            raise ValueError('Condition `status` must be one of ["True", "False", "Unknown"], not {}'.format(condition['status']))
+
+        if condition.get('reason') and not re.match(CAMEL_CASE, condition['reason']):
+            raise ValueError('Condition `reason` must be a single, CamelCase word')
+
+        for key in ['lastHeartBeatTime', 'lastTransitionTime']:
+            if condition.get(key) and not re.match(RFC3339_datetime, condition[key]):
+                raise ValueError('`{}` must be a RFC3339 compliant datetime string'.format(key))
+
+        return condition
+
+    return [validate_condition(c) for c in conditions]
+
+
+STATUS_ARG_SPEC = {
+    'status': {
+        'type': 'dict',
+        'required': False
+    },
+    'conditions': {
+        'type': condition_array,
+        'required': False
+    }
+}
+
+
+def main():
+    KubernetesAnsibleStatusModule().execute_module()
+
+
+class KubernetesAnsibleStatusModule(KubernetesAnsibleModule):
+
+    def __init__(self, *args, **kwargs):
+        KubernetesAnsibleModule.__init__(
+            self, *args,
+            supports_check_mode=True,
+            **kwargs
+        )
+        self.kind = self.params.get('kind')
+        self.api_version = self.params.get('api_version')
+        self.name = self.params.get('name')
+        self.namespace = self.params.get('namespace')
+        self.force = self.params.get('force')
+
+        self.status = self.params.get('status') or {}
+        self.conditions = self.params.get('conditions') or []
+
+        if self.conditions and self.status and self.status.get('conditions'):
+            raise ValueError("You cannot specify conditions in both the `status` and `conditions` parameters")
+
+        if self.conditions:
+            self.status['conditions'] = self.conditions
+
+    def execute_module(self):
+        self.client = self.get_api_client()
+
+        resource = self.find_resource(self.kind, self.api_version, fail=True)
+        if 'status' not in resource.subresources:
+            self.fail_json(msg='Resource {}.{} does not support the status subresource'.format(resource.api_version, resource.kind))
+
+        try:
+            instance = resource.get(name=self.name, namespace=self.namespace).to_dict()
+        except DynamicApiError as exc:
+            self.fail_json(msg='Failed to retrieve requested object: {0}'.format(exc),
+                           error=exc.summary())
+        # Make sure status is at least initialized to an empty dict
+        instance['status'] = instance.get('status', {})
+
+        if self.force:
+            self.exit_json(**self.replace(resource, instance))
+        else:
+            self.exit_json(**self.patch(resource, instance))
+
+    def replace(self, resource, instance):
+        if self.status == instance['status']:
+            return {'result': instance, 'changed': False}
+        instance['status'] = self.status
+        try:
+            result = resource.status.replace(body=instance).to_dict(),
+        except DynamicApiError as exc:
+            self.fail_json(msg='Failed to replace status: {}'.format(exc), error=exc.summary())
+
+        return {
+            'result': result,
+            'changed': True
+        }
+
+    def patch(self, resource, instance):
+        if self.object_contains(instance['status'], self.status):
+            return {'result': instance, 'changed': False}
+        instance['status'] = self.merge_status(instance['status'], self.status)
+        try:
+            result = resource.status.patch(body=instance, content_type='application/merge-patch+json').to_dict()
+        except DynamicApiError as exc:
+            self.fail_json(msg='Failed to replace status: {}'.format(exc), error=exc.summary())
+
+        return {
+            'result': result,
+            'changed': True
+        }
+
+    def merge_status(self, old, new):
+        old_conditions = old.get('conditions', [])
+        new_conditions = new.get('conditions', [])
+        if not (old_conditions and new_conditions):
+            return new
+
+        merged = copy.deepcopy(old_conditions)
+
+        for condition in new_conditions:
+            idx = self.get_condition_idx(merged, condition['type'])
+            if idx is not None:
+                merged[idx] = condition
+            else:
+                merged.append(condition)
+        new['conditions'] = merged
+        return new
+
+    def get_condition_idx(self, conditions, name):
+        for i, condition in enumerate(conditions):
+            if condition.get('type') == name:
+                return i
+        return None
+
+    def object_contains(self, obj, subset):
+        def dict_is_subset(obj, subset):
+            return all([mapping.get(type(obj.get(k)), mapping['default'])(obj.get(k), v) for (k, v) in subset.items()])
+
+        def list_is_subset(obj, subset):
+            return all(item in obj for item in subset)
+
+        def values_match(obj, subset):
+            return obj == subset
+
+        mapping = {
+            dict: dict_is_subset,
+            list: list_is_subset,
+            tuple: list_is_subset,
+            'default': values_match
+        }
+
+        return dict_is_subset(obj, subset)
+
+    @property
+    def argspec(self):
+        args = copy.deepcopy(COMMON_ARG_SPEC)
+        args.pop('state')
+        args.pop('resource_definition')
+        args.pop('src')
+        args.update(AUTH_ARG_SPEC)
+        args.update(STATUS_ARG_SPEC)
+        return args
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
@@ -16,21 +16,7 @@
   set_fact:
     deployed_templates_after: "{{ lookup('k8s', api_version=ct_status.results[0].result.apiVersion, kind='template') }}"
 
-- name: "Get common-templates-cr"
-  k8s:
-    state: present
-    definition: "{{ lookup('k8s', kind='KubevirtCommonTemplatesBundle', namespace=meta.namespace, resource_name='kubevirt-common-template-bundle') | from_yaml }}"
-  register: ct_cr
-
-- name: "Get latest progressive condition"
-  vars:
-    query: "result.status.conditions[?type=='Progressing'].{status: status, lastTransitionTime: lastTransitionTime}"
-    progressing_statuses: "{{ct_cr|json_query(query)}}"
-  set_fact:
-    last_progressing_status: "{{false if progressing_statuses|length == 0 else progressing_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
-
 - name: Set progressing condition
-  when: (not last_progressing_status) and (deployed_templates_before|length != deployed_templates_after|length)
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtCommonTemplatesBundle
@@ -38,40 +24,11 @@
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Progressing
-      status: "True"
-      reason: "deploying"
-      message: "Deploying templates."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-
-- name: Unset progressing condition
-  when: last_progressing_status and (deployed_templates_before|length == deployed_templates_after|length)
-  k8s_status:
-    api_version: kubevirt.io/v1
-    kind: KubevirtCommonTemplatesBundle
-    name: kubevirt-common-template-bundle
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: Progressing
-      status: "False"
-      reason: "deploying"
-      message: "Common templates deployed."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-
-- name: "Get common-templates-cr"
-  k8s:
-    state: present
-    definition: "{{ lookup('k8s', kind='KubevirtCommonTemplatesBundle', namespace=meta.namespace, resource_name='kubevirt-common-template-bundle') | from_yaml }}"
-  register: ct_cr
-
-- name: "Get latest available condition"
-  vars:
-    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
-    available_statuses: "{{ct_cr|json_query(query)}}"
-  set_fact:
-    last_available_status: "{{false if available_statuses|length == 0 else available_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+      status: "{{ 'True' if deployed_templates_before|length != deployed_templates_after|length else 'False' }}"
+      reason: "progressing"
+      message: "Templates progressing."
 
 - name: Set available condition
-  when: (not last_available_status) and (deployed_templates_before|length == deployed_templates_after|length)
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtCommonTemplatesBundle
@@ -79,72 +36,6 @@
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Available
-      status: "True"
-      reason: "deployed"
-      message: "Common templates deployed."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-
-- name: Unset available condition
-  when: last_available_status and (deployed_templates_before|length != deployed_templates_after|length)
-  k8s_status:
-    api_version: kubevirt.io/v1
-    kind: KubevirtCommonTemplatesBundle
-    name: kubevirt-common-template-bundle
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: Available
-      status: "False"
-      reason: "deployed"
-      message: "Common templates are missing some templates."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-
-
-- name: "Get common-templates-cr"
-  k8s:
-    state: present
-    definition: "{{ lookup('k8s', kind='KubevirtCommonTemplatesBundle', namespace=meta.namespace, resource_name='kubevirt-common-template-bundle') | from_yaml }}"
-  register: ct_cr
-
-- name: "Get any available condition"
-  vars:
-    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
-    available_statuses: "{{ct_cr|json_query(query)}}"
-  set_fact:
-    has_available_status: "{{false if available_statuses|length == 0 else true}}"
-
-# degraded condition will be set only if, nl was sometime available (it doesn't matter if condition was True or False), 
-# but now doesn't have enough pods
-- name: Set degraded condition
-  when: has_available_status and (deployed_templates_before|length != deployed_templates_after|length)
-  k8s_status:
-    api_version: kubevirt.io/v1
-    kind: KubevirtCommonTemplatesBundle
-    name: kubevirt-common-template-bundle
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: Degraded
-      status: "True"
-      reason: "degraded"
-      message: "Common templates are degraded."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-
-- name: "Get latest degraded condition"
-  vars:
-    query: "result.status.conditions[?type=='Degraded'].{status: status, lastTransitionTime: lastTransitionTime}"
-    degraded_statuses: "{{ct_cr|json_query(query)}}"
-  set_fact:
-    last_degraded_status: "{{false if degraded_statuses|length == 0 else degraded_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
-
-- name: Set degraded condition
-  when: last_degraded_status and (deployed_templates_before|length == deployed_templates_after|length)
-  k8s_status:
-    api_version: kubevirt.io/v1
-    kind: KubevirtCommonTemplatesBundle
-    name: kubevirt-common-template-bundle
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: Degraded
-      status: "False"
-      reason: "degraded"
-      message: "Common templates deployed."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+      status: "{{ 'True' if deployed_templates_before|length == deployed_templates_after|length else 'False' }}"
+      reason: "available"
+      message: "Common templates available."

--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -17,22 +17,7 @@
     definition: "{{ lookup('k8s', kind=nl.result.kind, namespace=nl.result.metadata.namespace, resource_name=nl.result.metadata.name) | from_yaml }}"
   register: nl_status
 
-- name: "Get node-labeller-cr"
-  k8s:
-    state: present
-    definition: "{{ lookup('k8s', kind='KubevirtNodeLabellerBundle', namespace=meta.namespace, resource_name='kubevirt-node-labeller-bundle') | from_yaml }}"
-  register: nl_cr
-
-- name: "Get latest progressive condition"
-  vars:
-    query: "result.status.conditions[?type=='Progressing'].{status: status, lastTransitionTime: lastTransitionTime}"
-    progressing_statuses: "{{nl_cr|json_query(query)}}"
-  set_fact:
-    last_progressing_status: "{{false if progressing_statuses|length == 0 else progressing_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
-
-
 - name: Set progressing condition
-  when: (not last_progressing_status) and (nl_status.result.status.currentNumberScheduled != nl_status.result.status.numberReady)
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
@@ -40,40 +25,22 @@
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Progressing
-      status: "True"
-      reason: "deploying"
-      message: "Deploying node-labeller."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+      status: "{{ 'True' if nl_status.result.status.currentNumberScheduled != nl_status.result.status.numberReady else 'False' }}"
+      reason: "progressing"
+      message: "Node-labeller is progressing."
 
-- name: Unset progressing condition
-  when: last_progressing_status and nl_status.result.status.currentNumberScheduled == nl_status.result.status.numberReady
-  k8s_status:
-    api_version: kubevirt.io/v1
-    kind: KubevirtNodeLabellerBundle
-    name: kubevirt-node-labeller-bundle
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: Progressing
-      status: "False"
-      reason: "deploying"
-      message: "Node-labeller has successfully progressed."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-
-- name: "Get node-labeller-cr"
-  k8s:
-    state: present
-    definition: "{{ lookup('k8s', kind='KubevirtNodeLabellerBundle', namespace=meta.namespace, resource_name='kubevirt-node-labeller-bundle') | from_yaml }}"
-  register: nl_cr
-
-- name: "Get latest available condition"
-  vars:
-    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
-    available_statuses: "{{nl_cr|json_query(query)}}"
-  set_fact:
-    last_available_status: "{{false if available_statuses|length == 0 else available_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
+- name:  "Wait for the node-labeller to start"
+  k8s_facts:
+    api_version: v1
+    kind: "{{ nl.result.kind }}"
+    name: "{{ nl.result.metadata.name }}"
+    namespace: "{{ nl.result.metadata.namespace }}"
+  register: nl_status
+  delay: 10
+  retries: 300
+  until: nl_status.resources[0].status.currentNumberScheduled == nl_status.resources[0].status.numberReady | default(false)
 
 - name: Set available condition
-  when: (not last_available_status) and (nl_status.result.status.currentNumberScheduled == nl_status.result.status.numberReady)
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
@@ -81,42 +48,11 @@
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Available
-      status: "True"
-      reason: "running"
-      message: "Node-labeller has required number of pods."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+      status: "{{ 'True' if nl_status.resources[0].status.currentNumberScheduled == nl_status.resources[0].status.numberReady else 'False' }}"
+      reason: "available"
+      message: "Node-labeller is available."
 
-- name: Unset available condition
-  when: last_available_status and (nl_status.result.status.currentNumberScheduled != nl_status.result.status.numberReady)
-  k8s_status:
-    api_version: kubevirt.io/v1
-    kind: KubevirtNodeLabellerBundle
-    name: kubevirt-node-labeller-bundle
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: Available
-      status: "False"
-      reason: "failed"
-      message: "Node-labeller hasn't got required number of pods."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-
-- name: "Get node-labeller-cr"
-  k8s:
-    state: present
-    definition: "{{ lookup('k8s', kind='KubevirtNodeLabellerBundle', namespace=meta.namespace, resource_name='kubevirt-node-labeller-bundle') | from_yaml }}"
-  register: nl_cr
-
-- name: "Get any available condition"
-  vars:
-    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
-    available_statuses: "{{nl_cr|json_query(query)}}"
-  set_fact:
-    has_available_status: "{{false if available_statuses|length == 0 else true}}"
-
-# degraded condition will be set only if, nl was sometime available (it doesn't matter if condition was True or False), 
-# but now doesn't have enough pods
-- name: Set degraded condition
-  when: has_available_status and (nl_status.result.status.currentNumberScheduled != nl_status.result.status.numberReady)
+- name: Set degraded condition 
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
@@ -124,28 +60,6 @@
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Degraded
-      status: "True"
+      status: "{{ 'True' if nl_status.resources[0].status.currentNumberScheduled != nl_status.resources[0].status.numberReady else 'False' }}"
       reason: "degraded"
       message: "Node-labeller is degraded."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-
-- name: "Get latest degraded condition"
-  vars:
-    query: "result.status.conditions[?type=='Degraded'].{status: status, lastTransitionTime: lastTransitionTime}"
-    degraded_statuses: "{{nl_cr|json_query(query)}}"
-  set_fact:
-    last_degraded_status: "{{false if degraded_statuses|length == 0 else degraded_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
-
-- name: Unset degraded condition
-  when: last_degraded_status and (nl_status.result.status.currentNumberScheduled == nl_status.result.status.numberReady)
-  k8s_status:
-    api_version: kubevirt.io/v1
-    kind: KubevirtNodeLabellerBundle
-    name: kubevirt-node-labeller-bundle
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: Degraded
-      status: "False"
-      reason: "degraded"
-      message: "Node-labeller has required number of pods."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -74,4 +74,3 @@
       status: "{{ 'True' if tv_status.resources[0].status.availableReplicas|default(0) != tv_status.resources[0].status.readyReplicas|default(2) else 'False' }}"
       reason: "degraded"
       message: "Template-validator is degraded."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -25,23 +25,9 @@
   set_fact:
     tv_status: "{{ lookup('k8s', kind=tv.results[3].result.kind, namespace=tv.results[3].result.metadata.namespace, resource_name=tv.results[3].result.metadata.name) | from_yaml }}"
 
-- name: "Get template-validator-cr"
-  k8s:
-    state: present
-    definition: "{{ lookup('k8s', kind='KubevirtTemplateValidator', namespace=meta.namespace, resource_name='kubevirt-template-validator') | from_yaml }}"
-  register: tv_cr
-
-- name: "Get latest progressive condition"
-  vars:
-    query: "result.status.conditions[?type=='Progressing'].{status: status, lastTransitionTime: lastTransitionTime}"
-    progressing_statuses: "{{tv_cr|json_query(query)}}"
-  set_fact:
-    tv_last_progressing_status: "{{false if progressing_statuses|length == 0 else progressing_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
-
 # defaults in this ansible code are here because at the start of deployment, there is a chance 
 # there will be no attributes like availableReplicas and readyReplicas
 - name: Set progressing condition
-  when: (not tv_last_progressing_status) and (tv_status.status.availableReplicas|default(0) != tv_status.status.readyReplicas|default(2))
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtTemplateValidator
@@ -49,40 +35,23 @@
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Progressing
-      status: "True"
-      reason: "deploying"
+      status: "{{ 'True' if tv_status.status.availableReplicas|default(0) != tv_status.status.readyReplicas|default(2) else 'False' }}"
+      reason: "progressing"
       message: "Template-validator is progressing."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
 
-- name: Unset progressing condition
-  when: tv_last_progressing_status and (tv_status.status.availableReplicas|default(0) == tv_status.status.readyReplicas|default(2))
-  k8s_status:
-    api_version: kubevirt.io/v1
-    kind: KubevirtTemplateValidator
-    name: kubevirt-template-validator
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: Progressing
-      status: "False"
-      reason: "deploying"
-      message: "Template-validator has successfully progressed."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+- name:  "Wait for the template-validator to start"
+  k8s_facts:
+    api_version: v1
+    kind: "{{ tv_status.kind }}"
+    name: "{{ tv_status.metadata.name }}"
+    namespace: "{{ tv_status.metadata.namespace }}"
+  register: tv_status
+  delay: 10
+  retries: 300
+  until: tv_status.resources[0].status.availableReplicas|default(0) == tv_status.resources[0].status.readyReplicas|default(2) | default(false)
 
-- name: "Get template-validator-cr"
-  k8s:
-    state: present
-    definition: "{{ lookup('k8s', kind='KubevirtTemplateValidator', namespace=meta.namespace, resource_name='kubevirt-template-validator') | from_yaml }}"
-  register: tv_cr
-
-- name: "Get latest available condition"
-  vars:
-    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
-    available_statuses: "{{tv_cr|json_query(query)}}"
-  set_fact:
-    tv_last_available_status: "{{false if available_statuses|length == 0 else available_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
 
 - name: Set available condition
-  when: (not tv_last_available_status) and (tv_status.status.availableReplicas|default(0) == tv_status.status.readyReplicas|default(2))
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtTemplateValidator
@@ -90,42 +59,11 @@
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Available
-      status: "True"
-      reason: "running"
-      message: "Template-validator is running."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+      status: "{{ 'True' if tv_status.resources[0].status.availableReplicas|default(0) == tv_status.resources[0].status.readyReplicas|default(2) else 'False' }}"
+      reason: "available"
+      message: "Template-validator is available."
 
-- name: Unset available condition
-  when: tv_last_available_status and (tv_status.status.availableReplicas|default(0) != tv_status.status.readyReplicas|default(2))
-  k8s_status:
-    api_version: kubevirt.io/v1
-    kind: KubevirtTemplateValidator
-    name: kubevirt-template-validator
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: Available
-      status: "False"
-      reason: "running"
-      message: "Template-validator hasn't got required number of pods."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-
-- name: "Get template-validator-cr"
-  k8s:
-    state: present
-    definition: "{{ lookup('k8s', kind='KubevirtTemplateValidator', namespace=meta.namespace, resource_name='kubevirt-template-validator') | from_yaml }}"
-  register: tv_cr
-
-- name: "Get any available condition"
-  vars:
-    query: "result.status.conditions[?type=='Available'].{status: status, lastTransitionTime: lastTransitionTime}"
-    available_statuses: "{{tv_cr|json_query(query)}}"
-  set_fact:
-    has_available_status: "{{false if available_statuses|length == 0 else true}}"
-
-# degraded condition will be set only if, tv was sometime available (it doesn't matter if condition was True or False), 
-# but now doesn't have enough pods
 - name: Set degraded condition
-  when: has_available_status and (tv_status.status.availableReplicas|default(0) != tv_status.status.readyReplicas|default(2))
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtTemplateValidator
@@ -133,28 +71,7 @@
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Degraded
-      status: "True"
+      status: "{{ 'True' if tv_status.resources[0].status.availableReplicas|default(0) != tv_status.resources[0].status.readyReplicas|default(2) else 'False' }}"
       reason: "degraded"
       message: "Template-validator is degraded."
-      lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-
-- name: "Get latest degraded condition"
-  vars:
-    query: "result.status.conditions[?type=='Degraded'].{status: status, lastTransitionTime: lastTransitionTime}"
-    degraded_statuses: "{{tv_cr|json_query(query)}}"
-  set_fact:
-    last_degraded_status: "{{false if degraded_statuses|length == 0 else degraded_statuses|sort(attribute='lastTransitionTime')|reverse|map(attribute='status')|first}}"
-
-- name: Unset degraded condition
-  when: last_degraded_status and (tv_status.status.availableReplicas|default(0) == tv_status.status.readyReplicas|default(2))
-  k8s_status:
-    api_version: kubevirt.io/v1
-    kind: KubevirtTemplateValidator
-    name: kubevirt-template-validator
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: Degraded
-      status: "False"
-      reason: "degraded"
-      message: "Template-validator has required number of pods."
       lastTransitionTime: "{{ ansible_date_time.iso8601 }}"


### PR DESCRIPTION
This PR contains refactored ssp operator conditions.

This PR Removes degraded condition for common templates - in this state it doesn't make sense to have it there,
because in every iteration all common templates will be installed.

This PR contains k8s_status.py file, which fixes bugs in k8s_status ansible module:
1) When CR condition is on index 0, then new condition with same type should replace old one.
But instead this new condition is appended to list of conditions.
2) object_contains function compares if new conditions are subset of old conditions, but due to lastTransitionTime
they are never subset. New conditions should not contain lastTransitionTime too. It will be set by kubernetes.
/cc @MarSik @fromanirh 