### PR TITLE
Fix dockerfile.registry to work with origin-operator-registry 4.2.0

### DIFF
--- a/build/Dockerfile.registry
+++ b/build/Dockerfile.registry
@@ -1,10 +1,13 @@
-FROM quay.io/openshift/origin-operator-registry
+FROM quay.io/openshift/origin-operator-registry:4.2.0
 
-COPY manifests /registry
+COPY manifests manifests
+
+# Bundle should include only manifests related to the CSV,
+# drop all additional files.
+RUN find manifests/kubevirt-ssp-operator/*/ -type f ! -name '*_crd.*' ! -name '*.clusterserviceversion.*' -exec rm -f {} \;
 
 # Initialize the database
-RUN rm -rf /registry/generated && \
-    initializer --manifests /registry --output bundles.db
+RUN initializer --manifests manifests/kubevirt-ssp-operator/ --output bundles.db
 
 # There are multiple binaries in the origin-operator-registry
 # We want the registry-server

--- a/build/Dockerfile.registry
+++ b/build/Dockerfile.registry
@@ -4,7 +4,7 @@ COPY manifests manifests
 
 # Bundle should include only manifests related to the CSV,
 # drop all additional files.
-RUN find manifests/kubevirt-ssp-operator/*/ -type f ! -name '*_crd.*' ! -name '*.clusterserviceversion.*' -exec rm -f {} \;
+RUN find manifests/kubevirt-ssp-operator/*/ -type f ! -name '*_crd.*' ! -name '*.clusterserviceversion.*' -exec rm -vf {} \;
 
 # Initialize the database
 RUN initializer --manifests manifests/kubevirt-ssp-operator/ --output bundles.db


### PR DESCRIPTION
Latest build of registry container fails with error: 
time="2019-08-19T10:13:44Z" level=fatal msg="permissive mode disabled" error="error loading manifests from directory: could not decode contents of file /registry/bundles.db into package: error converting YAML to JSON: yaml: control characters are not allowed"

This PR fixes this error (same issue as here: https://github.com/kubevirt/cluster-network-addons-operator/pull/215).

/cc @MarSik, @fromanirh 