### PR TITLE
rbac: restore list/watch permissions for pods

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -82,6 +82,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -142,6 +142,8 @@ spec:
           - pods
           verbs:
           - get
+          - list
+          - watch
         - apiGroups:
           - ''
           resources:


### PR DESCRIPTION
the `RepoInfo` role, which we currently not enable by default, need permissions to list and watch pods.
Without these permissions, the operator will fail to learn about the `ssp_registry`, thus will fail to deploy.

Signed-off-by: Francesco Romani <fromani@redhat.com>