### PR TITLE
Use CR's name from meta.name to set status

### DIFF
--- a/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
@@ -20,7 +20,7 @@
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtCommonTemplatesBundle
-    name: kubevirt-common-template-bundle
+    name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Progressing
@@ -32,7 +32,7 @@
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtCommonTemplatesBundle
-    name: kubevirt-common-template-bundle
+    name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Available

--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -21,7 +21,7 @@
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
-    name: kubevirt-node-labeller-bundle
+    name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Progressing
@@ -44,7 +44,7 @@
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
-    name: kubevirt-node-labeller-bundle
+    name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Available
@@ -56,7 +56,7 @@
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
-    name: kubevirt-node-labeller-bundle
+    name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Degraded

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -31,7 +31,7 @@
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtTemplateValidator
-    name: kubevirt-template-validator
+    name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Progressing
@@ -55,7 +55,7 @@
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtTemplateValidator
-    name: kubevirt-template-validator
+    name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Available
@@ -67,7 +67,7 @@
   k8s_status:
     api_version: kubevirt.io/v1
     kind: KubevirtTemplateValidator
-    name: kubevirt-template-validator
+    name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: Degraded


### PR DESCRIPTION
The k8s_status calls need to use the proper CR name to set status as users will not use the same names we use in our CI.

This fixes #86 