### PR TITLE
manifests: declare storage requests

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,6 +25,9 @@ spec:
           - containerPort: 60000
             name: metrics
           imagePullPolicy: Always
+          resources:
+            requests:
+              ephemeral-storage: "1Gi"
           env:
             - name: POD_NAME
               valueFrom:

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.6.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"version":"v0.6.1"}}]'
+    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.1.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"version":"v0.6.2"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.6.2"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}}]'
     capabilities: Basic Install
     categories: Virtualization
     description: Manages KubeVirt addons for Scheduling, Scale, Performance
@@ -204,7 +204,9 @@ spec:
                 ports:
                 - containerPort: 60000
                   name: metrics
-                resources: {}
+                resources:
+                  requests:
+                    ephemeral-storage: 1Gi
               serviceAccountName: kubevirt-ssp-operator
     strategy: deployment
   installModes:


### PR DESCRIPTION
Looking at the development clusters,  we see he pod requires >= 700M of storage.
We intentionally overestimate to 1G to have some safety.

Related-To: https://bugzilla.redhat.com/1748873
Signed-off-by: Francesco Romani <fromani@redhat.com>