### PR TITLE
manifests: force "Recreate" update strategy

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -18,6 +18,8 @@ spec:
         name: kubevirt-ssp-operator
     spec:
       serviceAccountName: kubevirt-ssp-operator
+      strategy:
+        type: Recreate
       containers:
         - name: kubevirt-ssp-operator
           image: REPLACE_IMAGE

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.6.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.0.5"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"version":"v0.6.1"}}]'
+    alm-examples: '[{"apiVersion":"kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"version":"v0.6.2"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.6.2"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}},{"apiVersion":"kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.1.1"}}]'
     capabilities: Basic Install
     categories: Virtualization
     description: Manages KubeVirt addons for Scheduling, Scale, Performance
@@ -178,7 +178,8 @@ spec:
           selector:
             matchLabels:
               name: kubevirt-ssp-operator
-          strategy: {}
+          strategy:
+            type: Recreate
           template:
             metadata:
               labels:


### PR DESCRIPTION
To let the upgrades go nicely and make good use of conditions reporting,
we need to make sure that k8s don't change things behind our back.
To do that, we force the update strategy to "Recreate".

Relevant OLM issues:
https://github.com/operator-framework/operator-lifecycle-manager/issues/1028
https://github.com/operator-framework/operator-lifecycle-manager/issues/952

Signed-off-by: Francesco Romani <fromani@redhat.com>