### PR TITLE
defaults: consolidate in ./_defaults.yml

### DIFF
--- a/_defaults.yml
+++ b/_defaults.yml
@@ -2,21 +2,12 @@
 # role values. This is useful for "downstream"
 # packaging and opinionated releases.
 #
-# If in doubt, leave the file empty.
-#
-# Example:
-#
-# validator_namespace: myproject
-# validator_image: registry.example.com/mine/kubevirt-template-validator
-# validator_tag: v0.6.1
-# templates_version: v0.6.2
+# this file should contain only the tags (~= versions) of the containers to install.
+# every other package/role specific value should sit in `roles/*/defaults/main.yml`.
 
----
-#node-labeller
 kubevirt_node_labeller_tag: "{{ lookup('env','NODE_LABELLER_TAG')| default('v0.1.1', true) }}"
 kvm_info_nfd_plugin_tag: "{{ lookup('env','KVM_INFO_TAG')| default('v0.5.8', true) }}"
 kubevirt_cpu_nfd_plugin_tag: "{{ lookup('env','CPU_PLUGIN_TAG')| default('v0.1.1', true) }}"
-virt_launcher_tag: "{{ lookup('env','VIRT_LAUNCHER_TAG')| default('v0.19.0', true) }}"
-
-#validator
+virt_launcher_tag: "{{ lookup('env','VIRT_LAUNCHER_TAG')| default('v0.21.0', true) }}"
 validator_tag: "{{ lookup('env','VALIDATOR_TAG')| default('v0.6.2', true) }}"
+templates_version: v0.7.0

--- a/_defaults.yml
+++ b/_defaults.yml
@@ -9,6 +9,13 @@
 #
 # A notable exception are common templates, on which we use a two-steps approach to allow the
 # users to easily override the installed version. Templates need to be special.
+#
+# When possible, the 'version' value in the CRs should take precedence over the defaults value.
+# The authoritative sources are, in decreasing priority order
+# 1. spec.version in the CRs (set by users)
+# 2. the *_TAG environment veriable (set by HCO)
+# 3. the builtin defaults (set by devs/operator)
+# Any version, or default, should not be set more than once in a place in the source tree.
 
 kubevirt_node_labeller_tag: "{{ lookup('env','NODE_LABELLER_TAG')| default('v0.1.1', true) }}"
 kvm_info_nfd_plugin_tag: "{{ lookup('env','KVM_INFO_TAG')| default('v0.5.8', true) }}"

--- a/_defaults.yml
+++ b/_defaults.yml
@@ -2,7 +2,9 @@
 # role values. This is useful for "downstream"
 # packaging and opinionated releases.
 #
-# this file should contain only the tags (~= versions) of the containers to install.
+# This file can be left empty to use the latest and greatest versions of all containers.
+# Or it can contain the tags (~= versions) of the containers to install if there is a known combination you want.
+# In case you really know what you are doing it is also possible to override the container names here.
 # every other package/role specific value should sit in `roles/*/defaults/main.yml`.
 
 kubevirt_node_labeller_tag: "{{ lookup('env','NODE_LABELLER_TAG')| default('v0.1.1', true) }}"

--- a/_defaults.yml
+++ b/_defaults.yml
@@ -15,6 +15,9 @@
 # 1. spec.version in the CRs (set by users)
 # 2. the *_TAG environment veriable (set by HCO)
 # 3. the builtin defaults (set by devs/operator)
+# 4. the per-role defaults, which is the last-resort value. Use a low-maintenance, usually working,
+#    easy to spot value. 'latest' is a good value here - probably the only case where we should use it.
+#
 # Any version, or default, should not be set more than once in a place in the source tree.
 
 kubevirt_node_labeller_tag: "{{ lookup('env','NODE_LABELLER_TAG')| default('v0.1.1', true) }}"

--- a/_defaults.yml
+++ b/_defaults.yml
@@ -6,6 +6,9 @@
 # Or it can contain the tags (~= versions) of the containers to install if there is a known combination you want.
 # In case you really know what you are doing it is also possible to override the container names here.
 # every other package/role specific value should sit in `roles/*/defaults/main.yml`.
+#
+# A notable exception are common templates, on which we use a two-steps approach to allow the
+# users to easily override the installed version. Templates need to be special.
 
 kubevirt_node_labeller_tag: "{{ lookup('env','NODE_LABELLER_TAG')| default('v0.1.1', true) }}"
 kvm_info_nfd_plugin_tag: "{{ lookup('env','KVM_INFO_TAG')| default('v0.5.8', true) }}"

--- a/roles/KubevirtCommonTemplatesBundle/defaults/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for KubevirtCommonTemplatesBundle
-version: "{{ templates_version }}"
+version: "{{ templates_version | default('latest') }}"

--- a/roles/KubevirtCommonTemplatesBundle/defaults/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for KubevirtCommonTemplatesBundle
-version: "{{ templates_version |default('v0.6.2') }}"
+version: "{{ templates_version }}"

--- a/roles/KubevirtCommonTemplatesBundle/defaults/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for KubevirtCommonTemplatesBundle
+version: "{{ templates_version |default('v0.6.2') }}"

--- a/roles/KubevirtCommonTemplatesBundle/defaults/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
 # defaults file for KubevirtCommonTemplatesBundle
-version: "{{ templates_version |default('v0.7.0') }}"
-

--- a/roles/KubevirtNodeLabeller/defaults/main.yml
+++ b/roles/KubevirtNodeLabeller/defaults/main.yml
@@ -2,12 +2,7 @@
 # defaults file for KubevirtNodeLabeller
 wait: true
 use_kvm: true
-
 kubevirt_node_labeller_image: "node-labeller"
-kubevirt_node_labeller_tag: "latest"
 kvm_info_nfd_plugin_image: "kvm-info-nfd-plugin"
-kvm_info_nfd_plugin_tag: "latest"
 kubevirt_cpu_nfd_plugin_image: "cpu-nfd-plugin"
-kubevirt_cpu_nfd_plugin_tag: "latest"
 virt_launcher_image: "virt-launcher"
-virt_launcher_tag: "latest"

--- a/roles/KubevirtTemplateValidator/defaults/main.yml
+++ b/roles/KubevirtTemplateValidator/defaults/main.yml
@@ -2,5 +2,3 @@
 # defaults file for KubevirtTemplateValidator
 wait: true
 validator_image: kubevirt-template-validator
-# this comes from the CR, we must diverge from validator_$SOMETHING standard naming
-version: "{{ validator_tag |default('v0.6.2') }}"

--- a/roles/KubevirtTemplateValidator/defaults/main.yml
+++ b/roles/KubevirtTemplateValidator/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for KubevirtTemplateValidator
 wait: true
 validator_image: kubevirt-template-validator
+validator_version: "{{ version | default(validator_tag, true) }}"

--- a/roles/KubevirtTemplateValidator/defaults/main.yml
+++ b/roles/KubevirtTemplateValidator/defaults/main.yml
@@ -2,4 +2,4 @@
 # defaults file for KubevirtTemplateValidator
 wait: true
 validator_image: kubevirt-template-validator
-validator_version: "{{ version | default(validator_tag, true) }}"
+validator_version: "{{ validator_tag }}"

--- a/roles/KubevirtTemplateValidator/defaults/main.yml
+++ b/roles/KubevirtTemplateValidator/defaults/main.yml
@@ -2,4 +2,4 @@
 # defaults file for KubevirtTemplateValidator
 wait: true
 validator_image: kubevirt-template-validator
-validator_version: "{{ validator_tag }}"
+validator_version: "{{ validator_tag | default('latest') }}"

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 # tasks file for KubevirtTemplateValidator
+- name: Figure out validator version
+  set_fact:
+    validator_version: "{{ version | default(validator_tag, true) }}"
 - name: Set template:view role
   k8s:
     state: present

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -1,8 +1,5 @@
 ---
 # tasks file for KubevirtTemplateValidator
-- name: Figure out validator version
-  set_fact:
-    validator_version: "{{ version | default(validator_tag, true) }}"
 - name: Set template:view role
   k8s:
     state: present

--- a/roles/KubevirtTemplateValidator/templates/service.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/service.yaml.j2
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: template-validator
       containers:
         - name: webhook
-          image: {{ ssp_registry | default("quay.io/fromani") }}/{{ validator_image }}:{{ version }}
+          image: {{ ssp_registry | default("quay.io/fromani") }}/{{ validator_image }}:{{ validator_version }}
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
We should have a single place on which we set the defaults,
and that place should be the toplevel _defaults.yml.
We should use per-role default only in rare, exceptional, well
documented cases, which we don't have now.

Signed-off-by: Francesco Romani <fromani@redhat.com>