### PR TITLE
Fix ssp operator image permissions

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -48,10 +48,12 @@ rules:
   - apps
   resources:
   - deployments
+  - deployments/finalizers
   - replicasets
   - daemonsets
   verbs:
   - create
+  - update
   - get
   - list
   - patch


### PR DESCRIPTION
This PR adds new permission to deploy manifest of ssp operator.
This new permission is needed to upgrade version of operator-sdk image.
//cc @MarSik, @fromanirh 

Signed-off-by: ksimon1 <ksimon@redhat.com>