### PR TITLE
implement a circuitbreaker-like utility role

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -3,6 +3,19 @@
 This document contains the most common issues reported when running the `kubevirt-ssp-operator`
 and their solutions.
 
+## Emergency disable
+
+Starting version 1.0.13, the SSP operator supports emergency disable of the operands it manages.
+To enable it, you need to add this annotation to the *kubevirt-ssp-operator* pod:
+```yaml
+    kubevirt.io/emergency-disable: |-
+      [
+        "kubevirt/kubevirt-template-validator"
+      ]
+```
+The value of the annotation must be a `JSON` list of `namespace/name` operands which should be temporarily
+ignored. 
+
 ## Openshift 3.11
 
 ### error: "cannot create clusterroles.rbac.authorization.k8s.io at the cluster scope"

--- a/playbooks/templatevalidator.yaml
+++ b/playbooks/templatevalidator.yaml
@@ -2,6 +2,7 @@
   vars_files:
     - _defaults.yml
   roles:
+  - KubevirtCircuitBreaker
 # we want to prepare everything to pull containers from the same repo
 # as the operator, but we are not there just yet, so we disable the role
 # and we rely on backward compatible defaults.

--- a/roles/KubevirtCircuitBreaker/defaults/main.yml
+++ b/roles/KubevirtCircuitBreaker/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for KubevirtCircuitBreaker

--- a/roles/KubevirtCircuitBreaker/handlers/main.yml
+++ b/roles/KubevirtCircuitBreaker/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for KubevirtCircuitBreaker

--- a/roles/KubevirtCircuitBreaker/meta/main.yml
+++ b/roles/KubevirtCircuitBreaker/meta/main.yml
@@ -1,0 +1,60 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 2.4
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/KubevirtCircuitBreaker/tasks/main.yml
+++ b/roles/KubevirtCircuitBreaker/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+# tasks file for KubevirtCircuitBreaker
+# 
+#
+- name: Extract the operator POD info
+  set_fact:
+    operator_pod: "{{ lookup('k8s', api_version='v1', kind='Pod', label_selector='name=kubevirt-ssp-operator') | from_yaml }}"
+- name: Extract the disable info
+  set_fact:
+    current_breaker: "{{ operator_pod['metadata'].get('annotations', {})['kubevirt.io/emergency-disable'] | default('[]', true) | from_json }}"
+    current_cr: "{{ meta.namespace }}/{{ meta.name }}"
+- name: Emergency disable check
+  meta: end_play
+  when: current_cr in current_breaker

--- a/roles/KubevirtCircuitBreaker/tests/inventory
+++ b/roles/KubevirtCircuitBreaker/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/KubevirtCircuitBreaker/vars/main.yml
+++ b/roles/KubevirtCircuitBreaker/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for KubevirtCircuitBreaker


### PR DESCRIPTION
This PR implements a circuitbreaker-like pattern for the SSP operator.
It is meant to be used very rarely, and only in the-sky-is-falling scenarios, when everything else failed.
For this reason the documentation is intentionally kept minimal, and the advertisement of this feature should be almost non-existant.

This PR want sto use the new role only in the component that's more likely to trigger a cascading failure: the template validator.