### PR TITLE
playbooks: enable circuitbreaker for all our CRs

### DIFF
--- a/playbooks/commontemplatesbundle.yaml
+++ b/playbooks/commontemplatesbundle.yaml
@@ -2,6 +2,9 @@
   vars_files:
     - _defaults.yml
   roles:
+  - role: KubevirtCircuitBreaker
+    vars:
+    - cr_kind: KubevirtCommonTemplatesBundle
 # we want to prepare everything to pull containers from the same repo
 # as the operator, but we are not there just yet, so we disable the role
 # and we rely on backward compatible defaults.

--- a/playbooks/kubevirtnodelabeller.yaml
+++ b/playbooks/kubevirtnodelabeller.yaml
@@ -2,6 +2,9 @@
   vars_files:
     - _defaults.yml
   roles:
+  - role: KubevirtCircuitBreaker
+    vars:
+    - cr_kind: KubevirtNodeLabellerBundle
 # we want to prepare everything to pull containers from the same repo
 # as the operator, but we are not there just yet, so we disable the role
 # and we rely on backward compatible defaults.

--- a/playbooks/metricsaggregation.yaml
+++ b/playbooks/metricsaggregation.yaml
@@ -3,4 +3,7 @@
   vars_files:
     - _defaults.yml
   roles:
+  - role: KubevirtCircuitBreaker
+    vars:
+    - cr_kind: KubevirtMetricsAggregation
   - KubevirtMetricsAggregation


### PR DESCRIPTION
We have use cases (on dev/QE envs) to pause the
reconciliations of all our CRs, so we enable
the role for all of them.

Signed-off-by: Francesco Romani <fromani@redhat.com>