### PR TITLE
travis: bump kubevirt version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 operator-sdk
 _out
+releases.json
+versionsrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,12 @@ before_script:
 ### And https://github.com/LiliC/travis-minikube/blob/e0f26f7b388057f51a0e2558afd5f990e07b6c49/.travis.yml#L11
 - sudo mount --make-rshared /
 
+- bash -x ci/ci/extra/get-kubevirt-releases
+
 - bash -x ci/prepare-host $CPLATFORM
 - bash -x ci/prepare-host virtctl
 - bash -x ci/start-cluster $CPLATFORM $CVER
-- bash -x ci/deploy-kubevirt $CPLATFORM
+- bash -x hack/deploy-kubevirt $CPLATFORM
 
 - bash -x hack/build-operator.sh
 - bash -x hack/install-operator.sh

--- a/hack/deploy-kubevirt
+++ b/hack/deploy-kubevirt
@@ -1,0 +1,6 @@
+#!/bin/bash
+# usage: deploy-kubevirt (minikube|minishift|oc_cluster) $KUBEVIRT_VERSION
+
+set -x
+
+$(dirname $(realpath $0))/../ci/deploy-kubevirt $1 $( $(dirname $(realpath $0))/../ci/ci/extra/cat-kubevirt-release last)


### PR DESCRIPTION
 ci: automation: automatically use the last k6t ver

Consume last traviskube changes to automatically test
against the latest kubevirt release, without the
need of manually updating .travis.yml