### PR TITLE
Custom image name prefix for the CSV generator

### DIFF
--- a/_defaults.yml
+++ b/_defaults.yml
@@ -25,4 +25,5 @@ kvm_info_nfd_plugin_tag: "{{ lookup('env','KVM_INFO_TAG')| default('v0.5.8', tru
 kubevirt_cpu_nfd_plugin_tag: "{{ lookup('env','CPU_PLUGIN_TAG')| default('v0.1.1', true) }}"
 virt_launcher_tag: "{{ lookup('env','VIRT_LAUNCHER_TAG')| default('v0.21.0', true) }}"
 validator_tag: "{{ lookup('env','VALIDATOR_TAG')| default('v0.6.2', true) }}"
+image_name_prefix: "{{ lookup('env','IMAGE_NAME_PREFIX')| default('', true) }}"
 templates_version: v0.7.0

--- a/build/csv-generator.sh
+++ b/build/csv-generator.sh
@@ -31,6 +31,7 @@ help_text() {
     echo "  --virt-launcher-tag: (OPTIONAL)"
     echo "  --node-labeller-tag: (OPTIONAL)"
     echo "  --cpu-plugin-tag:    (OPTIONAL)"
+    echo "  --image-name-prefix: (OPTIONAL)"
     echo "  --dump-crds:         (OPTIONAL) Dumps CRD manifests with the CSV to stdout"
 }
 
@@ -46,6 +47,7 @@ VALIDATOR_TAG=""
 VIRT_LAUNCHER_TAG=""
 NODE_LABELLER_TAG=""
 CPU_PLUGIN_TAG=""
+IMAGE_NAME_PREFIX=""
 DUMP_CRDS=""
 
 while (( "$#" )); do
@@ -81,6 +83,9 @@ while (( "$#" )); do
     --cpu-plugin-tag)
         CPU_PLUGIN_TAG=$VAL
         ;;
+    --image-name-prefix)
+        IMAGE_NAME_PREFIX=$VAL
+        ;;
     --dump-crds)
         DUMP_CRDS="true"
         ;;
@@ -114,6 +119,7 @@ replace_env_var "VALIDATOR_TAG" $VALIDATOR_TAG
 replace_env_var "VIRT_LAUNCHER_TAG" $VIRT_LAUNCHER_TAG
 replace_env_var "NODE_LABELLER_TAG" $NODE_LABELLER_TAG
 replace_env_var "CPU_PLUGIN_TAG" $CPU_PLUGIN_TAG
+replace_env_var "IMAGE_NAME_PREFIX" $IMAGE_NAME_PREFIX
 
 # dump CSV and CRD manifests to stdout
 echo "---"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -44,5 +44,7 @@ spec:
               value: ""
             - name: CPU_PLUGIN_TAG
               value: ""
+            - name: IMAGE_NAME_PREFIX
+              value: ""
             - name: OPERATOR_NAME
               value: "kubevirt-ssp-operator"

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -197,6 +197,7 @@ spec:
                 - name: VIRT_LAUNCHER_TAG
                 - name: NODE_LABELLER_TAG
                 - name: CPU_PLUGIN_TAG
+                - name: IMAGE_NAME_PREFIX
                 - name: OPERATOR_NAME
                   value: kubevirt-ssp-operator
                 image: REPLACE_IMAGE

--- a/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
+++ b/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
@@ -18,13 +18,13 @@ spec:
       serviceAccount: kubevirt-node-labeller
       containers:
       - name: kubevirt-node-labeller-sleeper
-        image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
+        image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
         command: ["sleep"]
         args: ["infinity"]
       initContainers:
 
         - name: kvm-info-nfd-plugin
-          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ kvm_info_nfd_plugin_image }}:{{ kvm_info_nfd_plugin_tag }}
+          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kvm_info_nfd_plugin_image }}:{{ kvm_info_nfd_plugin_tag }}
           command: ["/bin/sh","-c"]
           args: ["cp /usr/bin/kvm-caps-info-nfd-plugin /etc/kubernetes/node-feature-discovery/source.d/;"]
           imagePullPolicy: Always
@@ -33,7 +33,7 @@ spec:
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
 
         - name: kubevirt-cpu-nfd-plugin
-          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ kubevirt_cpu_nfd_plugin_image }}:{{ kubevirt_cpu_nfd_plugin_tag }}
+          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_cpu_nfd_plugin_image }}:{{ kubevirt_cpu_nfd_plugin_tag }}
           command: ["/bin/sh","-c"]
           args: ["cp /plugin/dest/cpu-nfd-plugin /etc/kubernetes/node-feature-discovery/source.d/; cp /config/cpu-plugin-configmap.yaml /etc/kubernetes/node-feature-discovery/source.d/cpu-plugin-configmap.yaml;"]
           imagePullPolicy: Always
@@ -44,7 +44,7 @@ spec:
               name: cpu-config
 
         - name: libvirt
-          image: {{ ssp_registry | default('kubevirt') }}/{{ virt_launcher_image }}:{{ virt_launcher_tag }}
+          image: {{ ssp_registry | default('kubevirt') }}/{{ image_name_prefix }}{{ virt_launcher_image }}:{{ virt_launcher_tag }}
           command: ["/bin/sh","-c"]
 {% if use_kvm %}
           args: ["libvirtd -d; chmod o+rw /dev/kvm; virsh domcapabilities --machine q35 --arch x86_64 --virttype kvm > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
@@ -70,7 +70,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
+          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
 {% if use_kvm %}
           securityContext:
             privileged: true


### PR DESCRIPTION
Let the user specify a custom image name prefix
running the CSV generator.
The default value is an empty string.

Fixes: https://bugzilla.redhat.com/1757798

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>