### PR TITLE
Custom image name prefix for template-validator

### DIFF
--- a/roles/KubevirtTemplateValidator/templates/service.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/service.yaml.j2
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: template-validator
       containers:
         - name: webhook
-          image: {{ ssp_registry | default("quay.io/fromani") }}/{{ validator_image }}:{{ validator_version }}
+          image: {{ ssp_registry | default("quay.io/fromani") }}/{{ image_name_prefix }}{{ validator_image }}:{{ validator_version }}
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
Let the user specify a custom image name prefix
for the template-validator as well.

This fixes one place we forgot to change in the previous PR.

Fixes: https://bugzilla.redhat.com/1757798

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>