### PR TITLE
rename use_kvm to useKVM

### DIFF
--- a/functests/node-labeller-unversioned-cr.yaml
+++ b/functests/node-labeller-unversioned-cr.yaml
@@ -3,4 +3,4 @@ kind: KubevirtNodeLabellerBundle
 metadata:
   name: kubevirt-node-labeller-bundle
 spec:
-  use_kvm: false
+  useKVM: false

--- a/pkg/apis/kubevirt/v1/types.go
+++ b/pkg/apis/kubevirt/v1/types.go
@@ -70,7 +70,7 @@ type VersionSpec struct {
 
 type ComponentSpec struct {
 	Version string `json:"version,omitempty"`
-	UseKVM  bool   `json:"use_kvm"`
+	UseKVM  bool   `json:"useKVM"`
 }
 
 type TemplateValidatorSpec struct {

--- a/roles/KubevirtNodeLabeller/defaults/main.yml
+++ b/roles/KubevirtNodeLabeller/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for KubevirtNodeLabeller
 wait: true
-use_kvm: true
+useKVM: true
 kubevirt_node_labeller_image: "node-labeller"
 kvm_info_nfd_plugin_image: "kvm-info-nfd-plugin"
 kubevirt_cpu_nfd_plugin_image: "cpu-nfd-plugin"

--- a/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
+++ b/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
@@ -46,13 +46,13 @@ spec:
         - name: libvirt
           image: {{ ssp_registry | default('kubevirt') }}/{{ image_name_prefix }}{{ virt_launcher_image }}:{{ virt_launcher_tag }}
           command: ["/bin/sh","-c"]
-{% if use_kvm %}
+{% if useKVM %}
           args: ["libvirtd -d; chmod o+rw /dev/kvm; virsh domcapabilities --machine q35 --arch x86_64 --virttype kvm > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
 {% else %}
           args: ["libvirtd -d; virsh domcapabilities --machine q35 --arch x86_64 --virttype qemu > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
 {% endif %}
           imagePullPolicy: Always
-{% if use_kvm %}
+{% if useKVM %}
           securityContext:
             privileged: true
           resources:
@@ -71,7 +71,7 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
           image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
-{% if use_kvm %}
+{% if useKVM %}
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
name useKVM should be more consistent to kubernetes naming convention

Signed-off-by: ksimon1 <ksimon@redhat.com>