### PR TITLE
pkg: always send `use_kvm`

### DIFF
--- a/pkg/apis/kubevirt/v1/types.go
+++ b/pkg/apis/kubevirt/v1/types.go
@@ -70,7 +70,7 @@ type VersionSpec struct {
 
 type ComponentSpec struct {
 	Version string `json:"version,omitempty"`
-	UseKVM  bool   `json:"use_kvm,omitempty"`
+	UseKVM  bool   `json:"use_kvm"`
 }
 
 type TemplateValidatorSpec struct {


### PR DESCRIPTION
We need to erase the "omitempty" annotation from the
KubeVirtNodeLabellerBundle CR, otherwise the client code (HCO)
will not be able to send `use_kvm: false`, because:

```
The "omitempty" option specifies that the field should be omitted
from the encoding if the field has an empty value,
defined as **false**, 0, a nil pointer, a nil interface value,
and any empty array, slice, map, or string.
```

Source: https://golang.org/pkg/encoding/json/#Marshal

Backport-To: stable-1.0.13
Related-To: https://github.com/kubevirt/hyperconverged-cluster-operator/pull/276
Signed-off-by: Francesco Romani <fromani@redhat.com>