### PR TITLE
node-labeller: use snake-case internally, again.

### DIFF
--- a/roles/KubevirtNodeLabeller/defaults/main.yml
+++ b/roles/KubevirtNodeLabeller/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for KubevirtNodeLabeller
 wait: true
-useKVM: true
+use_kvm: true
 kubevirt_node_labeller_image: "node-labeller"
 kvm_info_nfd_plugin_image: "kvm-info-nfd-plugin"
 kubevirt_cpu_nfd_plugin_image: "cpu-nfd-plugin"

--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -25,7 +25,7 @@
     namespace: "{{ meta.namespace }}"
     conditions:
     - type: KVMSupport
-      status: "{{ useKVM }}"
+      status: "{{ use_kvm }}"
       reason: "enabled"
       message: "KVM support is enabled."
 

--- a/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
+++ b/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
@@ -46,13 +46,13 @@ spec:
         - name: libvirt
           image: {{ ssp_registry | default('kubevirt') }}/{{ image_name_prefix }}{{ virt_launcher_image }}:{{ virt_launcher_tag }}
           command: ["/bin/sh","-c"]
-{% if useKVM %}
+{% if use_kvm %}
           args: ["libvirtd -d; chmod o+rw /dev/kvm; virsh domcapabilities --machine q35 --arch x86_64 --virttype kvm > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
 {% else %}
           args: ["libvirtd -d; virsh domcapabilities --machine q35 --arch x86_64 --virttype qemu > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
 {% endif %}
           imagePullPolicy: Always
-{% if useKVM %}
+{% if use_kvm %}
           securityContext:
             privileged: true
           resources:
@@ -71,7 +71,7 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
           image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
-{% if useKVM %}
+{% if use_kvm %}
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
When the ansible operator creates the playbook parameters,
it takes all the attributes under `spec:` and creates
variables out of them.
However, the variable names are not taken verbatim, but
they are translated to snake_case:
https://github.com/operator-framework/operator-sdk/blob/v0.11.x/pkg/ansible/runner/runner.go#L259

So the role variables should always use the snake_case variant
automatically created, not the camelCase exposed version.
Out of necessity, this commit undoes most of the changes
done in 83528c8 because we had the following bug:

1. HCO wants to set useKVM=false when running on its CI
2. the ansible operator translates the variable to use_kvm=false
   and pass the parameter to the playbook
3. the playbook runs, and sets the defaults useKVM=true
4. the playbook consumes the useKVM (camelCase) variable, whose
   defaults has been set and never overriden
5. the use_kvm (snake_case) variable, which holds the correct value
   the user set (in the CR spec.useKVM!) is ignored entirely.

So the only fix is expose fields to kubernetes in camelCase (useKVM) but
consume their snake_case counterparts (use_kvm) in the roles.

Signed-off-by: Francesco Romani <fromani@redhat.com>