### PR TITLE
roles: repoinfo: simplify autodetection

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -32,7 +32,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: IMAGE_NAME
+            - name: IMAGE_REFERENCE
               value: REPLACE_IMAGE
             - name: WATCH_NAMESPACE
               value: ""

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -32,6 +32,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: IMAGE_NAME
+              value: REPLACE_IMAGE
             - name: WATCH_NAMESPACE
               value: ""
             - name: KVM_INFO_TAG

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -191,6 +191,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: IMAGE_NAME
+                  value: REPLACE_IMAGE
                 - name: WATCH_NAMESPACE
                 - name: KVM_INFO_TAG
                 - name: VALIDATOR_TAG

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -191,7 +191,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
-                - name: IMAGE_NAME
+                - name: IMAGE_REFERENCE
                   value: REPLACE_IMAGE
                 - name: WATCH_NAMESPACE
                 - name: KVM_INFO_TAG

--- a/roles/KubevirtRepoInfo/tasks/main.yml
+++ b/roles/KubevirtRepoInfo/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for KubevirtRepoInfo
 - name: Extract the image name
   set_fact:
-    operator_image_name: "{{ lookup('env', 'IMAGE_NAME') | default('quay.io/kubevirt/kubevirt-ssp-operator-container:latest', true }}"
+    operator_image_name: "{{ lookup('env', 'IMAGE_REFERENCE') | default('quay.io/kubevirt/kubevirt-ssp-operator-container:latest', true) }}"
 - name: Extract the SSP registry
   set_fact:
     ssp_registry: "{{ operator_image_name.rsplit('/', 1)[0] }}"

--- a/roles/KubevirtRepoInfo/tasks/main.yml
+++ b/roles/KubevirtRepoInfo/tasks/main.yml
@@ -1,11 +1,8 @@
 ---
 # tasks file for KubevirtRepoInfo
-- name: Extract the operator POD info
-  set_fact:
-    operator_pod: "{{ lookup('k8s', api_version='v1', kind='Pod', label_selector='name=kubevirt-ssp-operator') | from_yaml }}"
 - name: Extract the image name
   set_fact:
-    operator_image_name: "{{ operator_pod['spec']['containers'][0]['image'] }}"
+    operator_image_name: "{{ lookup('env', 'IMAGE_NAME') | default('quay.io/kubevirt/kubevirt-ssp-operator-container:latest', true }}"
 - name: Extract the SSP registry
   set_fact:
     ssp_registry: "{{ operator_image_name.rsplit('/', 1)[0] }}"


### PR DESCRIPTION
We can do much like kubevirt core does: set the image path
in the manifests themselves inside that introspect at runtime.
This is simpler and much more robust when doing upgrades.

Signed-off-by: Francesco Romani <fromani@redhat.com>