### PR TITLE
Hotfix csv generator to support inline yaml

### DIFF
--- a/build/csv-generator.sh
+++ b/build/csv-generator.sh
@@ -15,7 +15,9 @@ replace_env_var() {
     local value_offset="                  "
     local key=$1
     local var=$2
+    # Make sure to replace both valid YAML variants, structured and inline
     sed -i "s/- name: ${key}/- name: $1\n${value_offset}value: \"${var}\"/g" ${TMP_FILE}
+    sed -i "s/{name: ${key}}/{name: $1, value: \"${var}\"}/g" ${TMP_FILE}
 }
 
 help_text() {


### PR DESCRIPTION
The csv-generator was originally written to replace
env values in the form of

- name: NAME
  value: ....

But the currently generated manifest uses the inline form:

- {name: NAME, value: ...}

This patch updates the script so both forms are supported.

Signed-off-by: Martin Sivak <msivak@redhat.com>