### PR TITLE
Install pip3 packages in the users home folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ operator-sdk:
 	chmod 0755 operator-sdk
 
 operator-courier:
-	pip3 install operator-courier
+	pip3 install --user operator-courier
 
 manifests-prepare:
 	mkdir -p _out


### PR DESCRIPTION
Avoid the need for extra privileges when running `make manifests`.