### PR TITLE
ClusterRole: add missing permission

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -66,6 +66,7 @@ rules:
   - services
   verbs:
   - create
+  - update
   - get
   - patch
   - list

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ spec:
           verbs: [create, update, get, list, patch, watch]
         - apiGroups: ['']
           resources: [serviceaccounts, configmaps, services]
-          verbs: [create, get, patch, list, watch]
+          verbs: [create, update, get, patch, list, watch]
         - apiGroups: ['']
           resources: [nodes]
           verbs: [get, patch, update]


### PR DESCRIPTION
add missing update permission to services
Due to this missing permission, ssp operator failed to start on OCP 4.3.
//cc @fromanirh, @MarSik 
Signed-off-by: Karel Šimon <ksimon@redhat.com>