### PR TITLE
add missing python dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ addons:
   apt:
     packages:
     - python3-pip
+    - python3-setuptools
+    - python3-wheel
 
 cache:
   directories:


### PR DESCRIPTION
operator-courier needs some more python dependencies

Signed-off-by: Karel Šimon <ksimon@redhat.com>