### PR TITLE
[WIP ]decreased timeout time in "wait" tasks

### DIFF
--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -49,8 +49,9 @@
     namespace: "{{ nl.result.metadata.namespace }}"
   register: nl_status
   delay: 10
-  retries: 300
+  retries: 6
   until: nl_status.resources[0].status.currentNumberScheduled == nl_status.resources[0].status.numberReady | default(false)
+  ignore_errors: yes
 
 - name: Set available condition
   k8s_status:

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -47,9 +47,9 @@
     namespace: "{{ tv_status.metadata.namespace }}"
   register: tv_status
   delay: 10
-  retries: 300
+  retries: 6
   until: tv_status.resources[0].status.availableReplicas|default(0) == tv_status.resources[0].status.readyReplicas|default(2) | default(false)
-
+  ignore_errors: yes
 
 - name: Set available condition
   k8s_status:


### PR DESCRIPTION
decreased timeout time in "wait" tasks
This change should prevent uncontrollable "freeze" of ssp operator.
This "freeze" happens in this scenario(mostly during tests): e.g. template-validator
is deployed. Then ansible moves to "Wait for the template-validator to start" task.
But when user (or script) deletes template-validator CR, operator keeps trying to test
if validator is online or not (in this case for more than 3000 seconds) and then operator fails
and whole container is restarted. This patch decrease this time to only 60 seconds and prevents restarts
of container by adding flag ignore_errors to "wait" tasks (for now only validator + node-labeller have this task)

Signed-off-by: Karel Šimon <ksimon@redhat.com>