### PR TITLE
add manifests validation into travis tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ manifests: operator-courier csv-generator manifests-cleanup manifests-prepare op
 
 release: manifests container-build container-release
 
-functests:
+functests: manifests
 	cd functests && ./test-runner.sh
 
 .PHONY: functests release manifests manifests-prepare manifests-cleanup container-push container-build container-release


### PR DESCRIPTION
Sometimes, when release manifests are updated, they contains error. Validation of manifests happens
only during releases. With this change, we should be able to find out error
during PR review.
Fixes https://github.com/MarSik/kubevirt-ssp-operator/issues/134

Signed-off-by: Karel Šimon <ksimon@redhat.com>