### PR TITLE
Make deployment template compatible with 'sha256:' tags

### DIFF
--- a/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
+++ b/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
@@ -18,13 +18,13 @@ spec:
       serviceAccount: kubevirt-node-labeller
       containers:
       - name: kubevirt-node-labeller-sleeper
-        image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
+        image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_node_labeller_image }}{{"@" if kubevirt_node_labeller_tag.startswith("sha256:") else ":" }}{{ kubevirt_node_labeller_tag }}
         command: ["sleep"]
         args: ["infinity"]
       initContainers:
 
         - name: kvm-info-nfd-plugin
-          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kvm_info_nfd_plugin_image }}:{{ kvm_info_nfd_plugin_tag }}
+          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kvm_info_nfd_plugin_image }}{{"@" if kvm_info_nfd_plugin_tag.startswith("sha256:") else ":" }}{{ kvm_info_nfd_plugin_tag }}
           command: ["/bin/sh","-c"]
           args: ["cp /usr/bin/kvm-caps-info-nfd-plugin /etc/kubernetes/node-feature-discovery/source.d/;"]
           imagePullPolicy: Always
@@ -33,7 +33,7 @@ spec:
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
 
         - name: kubevirt-cpu-nfd-plugin
-          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_cpu_nfd_plugin_image }}:{{ kubevirt_cpu_nfd_plugin_tag }}
+          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_cpu_nfd_plugin_image }}{{"@" if kubevirt_cpu_nfd_plugin_tag.startswith("sha256:") else ":" }}{{ kubevirt_cpu_nfd_plugin_tag }}
           command: ["/bin/sh","-c"]
           args: ["cp /plugin/dest/cpu-nfd-plugin /etc/kubernetes/node-feature-discovery/source.d/; cp /config/cpu-plugin-configmap.yaml /etc/kubernetes/node-feature-discovery/source.d/cpu-plugin-configmap.yaml;"]
           imagePullPolicy: Always
@@ -44,7 +44,7 @@ spec:
               name: cpu-config
 
         - name: libvirt
-          image: {{ ssp_registry | default('kubevirt') }}/{{ image_name_prefix }}{{ virt_launcher_image }}:{{ virt_launcher_tag }}
+          image: {{ ssp_registry | default('kubevirt') }}/{{ image_name_prefix }}{{ virt_launcher_image }}{{"@" if virt_launcher_tag.startswith("sha256:") else ":" }}{{ virt_launcher_tag }}
           command: ["/bin/sh","-c"]
 {% if use_kvm %}
           args: ["libvirtd -d; chmod o+rw /dev/kvm; virsh domcapabilities --machine q35 --arch x86_64 --virttype kvm > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
@@ -70,7 +70,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_node_labeller_image }}:{{ kubevirt_node_labeller_tag }}
+          image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_node_labeller_image }}{{"@" if kubevirt_node_labeller_tag.startswith("sha256:") else ":" }}{{ kubevirt_node_labeller_tag }}
 {% if use_kvm %}
           securityContext:
             privileged: true

--- a/roles/KubevirtTemplateValidator/templates/service.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/service.yaml.j2
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: template-validator
       containers:
         - name: webhook
-          image: {{ ssp_registry | default("quay.io/kubevirt") }}/{{ image_name_prefix }}{{ validator_image }}:{{ validator_version }}
+          image: {{ ssp_registry | default("quay.io/kubevirt") }}/{{ image_name_prefix }}{{ validator_image }}{{"@" if validator_version.startswith("sha256:") else ":" }}{{ validator_version }}
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
Image pull URLs can contain ':tag' or '@sha256:digest' so we
have to make deployment templates compatible with both the syntax
instead of hardcoding ':' as the separator and always assuming
that the env variable always contains a plain tag.
Now the templates will check if the tag variable starts with
'sha256:' and in that case it will use '@' as the delimiter
as other operators are doing.