### PR TITLE
Template validator update deployment api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Operator that manages Scheduling, Scale and Performance addons for [KubeVirt](ht
 
 - Golang environment and GOPATH correctly set
 - Docker (used for creating container images, etc.) with access for the current user
-- a Kubernetes/OpenShift/Minikube/Minishift instance
+- a Kubernetes 1.13 /OpenShift 4 instance
 - [Operator SDK](https://github.com/operator-framework/operator-sdk)
 
 ## Installation instructions

--- a/functests/05-test_need_OCP4-deploy-template-validator.sh
+++ b/functests/05-test_need_OCP4-deploy-template-validator.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# This script needs openshift 4.*
+
 SCRIPTPATH=$( dirname $(readlink -f $0) )
 source ${SCRIPTPATH}/testlib.sh
 

--- a/roles/KubevirtTemplateValidator/templates/service.yaml.j2
+++ b/roles/KubevirtTemplateValidator/templates/service.yaml.j2
@@ -40,7 +40,7 @@ spec:
   selector:
     kubevirt.io: virt-template-validator
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: virt-template-validator
@@ -49,6 +49,9 @@ metadata:
     name: virt-template-validator
 spec:
   replicas: {{ replicas }}
+  selector:
+    matchLabels:
+      kubevirt.io: virt-template-validator
   template:
     metadata:
       name: virt-template-validator


### PR DESCRIPTION
apiVersion: apps/v1beta is deprecated and will be removed in future version of openshift.
This PR changes it to apiVersion: apps/v1.
Due to this change another label selector has to be added into spec.selector in deployment.
Disable validator test, because it needs openshift 4, which is currently not available for travis.