### PR TITLE
updated api group in crd and crs to ssp.kubevirt.io

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -6,18 +6,18 @@ and their solutions.
 ## Emergency disable
 
 Starting version 1.0.14, the SSP operator supports emergency disable of the operands it manages.
-To engage this feature, you need to set the `kubevirt.io/operator.paused` annotation to `true` in the CR you want to disable.
+To engage this feature, you need to set the `ssp.kubevirt.io/operator.paused` annotation to `true` in the CR you want to disable.
 Add the key if missing.
 
 Example:
 ```yaml
-apiVersion: kubevirt.io/v1
+apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtTemplateValidator
 metadata:
   name: kubevirt-template-validator
   namespace: kubevirt
   annotations:
-    kubevirt.io/operator.paused: "true"
+    ssp.kubevirt.io/operator.paused: "true"
 spec:
   version: v0.6.2
 ```

--- a/build/update-olm.py
+++ b/build/update-olm.py
@@ -49,7 +49,7 @@ _SPEC = {
 }
 
 _CRD_INFOS = {
-    'kubevirttemplatevalidators.kubevirt.io': {
+    'kubevirttemplatevalidators.ssp.kubevirt.io': {
         'displayName': 'KubeVirt Template Validator admission webhook',
         'description': \
                 'Represents a deployment of admission control webhook to validate the KubeVirt templates',
@@ -63,7 +63,7 @@ _CRD_INFOS = {
             ],
         }],
     },
-    'kubevirtcommontemplatesbundles.kubevirt.io': {
+    'kubevirtcommontemplatesbundles.ssp.kubevirt.io': {
         'displayName': 'KubeVirt common templates',
         'description': \
                 'Represents a deployment of the predefined VM templates',
@@ -77,7 +77,7 @@ _CRD_INFOS = {
             ],
         }],
     },
-    'kubevirtnodelabellerbundles.kubevirt.io': {
+    'kubevirtnodelabellerbundles.ssp.kubevirt.io': {
         'displayName': 'KubeVirt Node labeller',
         'description': \
                 'Represents a deployment of Node labeller component',
@@ -91,7 +91,7 @@ _CRD_INFOS = {
             ],
         }],
     },
-    'kubevirtmetricsaggregations.kubevirt.io': {
+    'kubevirtmetricsaggregations.ssp.kubevirt.io': {
         'displayName': 'KubeVirt Metric Aggregation',
         'description': \
                 'Provide aggregation rules for core kubevirt metrics',

--- a/deploy/crds/kubevirt_v1_commontemplatesbundle_cr.yaml
+++ b/deploy/crds/kubevirt_v1_commontemplatesbundle_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1
+apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtCommonTemplatesBundle
 metadata:
   name: kubevirt-common-template-bundle

--- a/deploy/crds/kubevirt_v1_commontemplatesbundle_crd.yaml
+++ b/deploy/crds/kubevirt_v1_commontemplatesbundle_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kubevirtcommontemplatesbundles.kubevirt.io
+  name: kubevirtcommontemplatesbundles.ssp.kubevirt.io
 spec:
-  group: kubevirt.io
+  group: ssp.kubevirt.io
   names:
     kind: KubevirtCommonTemplatesBundle
     listKind: KubevirtCommonTemplatesBundleList

--- a/deploy/crds/kubevirt_v1_metricsaggregation_cr.yaml
+++ b/deploy/crds/kubevirt_v1_metricsaggregation_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1
+apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtMetricsAggregation
 metadata:
   name: kubevirt-metrics-aggregation

--- a/deploy/crds/kubevirt_v1_metricsaggregation_crd.yaml
+++ b/deploy/crds/kubevirt_v1_metricsaggregation_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kubevirtmetricsaggregations.kubevirt.io
+  name: kubevirtmetricsaggregations.ssp.kubevirt.io
 spec:
-  group: kubevirt.io
+  group: ssp.kubevirt.io
   names:
     kind: KubevirtMetricsAggregation
     listKind: KubevirtMetricsAggregationList

--- a/deploy/crds/kubevirt_v1_nodelabellerbundle_cr.yaml
+++ b/deploy/crds/kubevirt_v1_nodelabellerbundle_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1
+apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtNodeLabellerBundle
 metadata:
   name: kubevirt-node-labeller-bundle

--- a/deploy/crds/kubevirt_v1_nodelabellerbundle_crd.yaml
+++ b/deploy/crds/kubevirt_v1_nodelabellerbundle_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kubevirtnodelabellerbundles.kubevirt.io
+  name: kubevirtnodelabellerbundles.ssp.kubevirt.io
 spec:
-  group: kubevirt.io
+  group: ssp.kubevirt.io
   names:
     kind: KubevirtNodeLabellerBundle
     listKind: KubevirtNodeLabellerBundleList

--- a/deploy/crds/kubevirt_v1_templatevalidator_cr.yaml
+++ b/deploy/crds/kubevirt_v1_templatevalidator_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1
+apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtTemplateValidator
 metadata:
   name: kubevirt-template-validator

--- a/deploy/crds/kubevirt_v1_templatevalidator_crd.yaml
+++ b/deploy/crds/kubevirt_v1_templatevalidator_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kubevirttemplatevalidators.kubevirt.io
+  name: kubevirttemplatevalidators.ssp.kubevirt.io
 spec:
-  group: kubevirt.io
+  group: ssp.kubevirt.io
   names:
     kind: KubevirtTemplateValidator
     listKind: KubevirtTemplateValidatorList

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -5,6 +5,7 @@ metadata:
 rules:
 - apiGroups:
   - kubevirt.io
+  - ssp.kubevirt.io
   - template.openshift.io
   resources:
   - '*'

--- a/functests/aggregation-rules-unversioned-cr.yaml
+++ b/functests/aggregation-rules-unversioned-cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1
+apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtMetricsAggregation
 metadata:
   name: kubevirt-metrics-aggregation

--- a/functests/common-templates-versioned-cr.yaml
+++ b/functests/common-templates-versioned-cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1
+apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtCommonTemplatesBundle
 metadata:
   name: kubevirt-common-template-bundle

--- a/functests/node-labeller-unversioned-cr.yaml
+++ b/functests/node-labeller-unversioned-cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1
+apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtNodeLabellerBundle
 metadata:
   name: kubevirt-node-labeller-bundle

--- a/functests/template-validator-unversioned-cr.yaml
+++ b/functests/template-validator-unversioned-cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1
+apiVersion: ssp.kubevirt.io/v1
 kind: KubevirtTemplateValidator
 metadata:
   name: kubevirt-template-validator

--- a/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Set progressing condition
   k8s_status:
-    api_version: kubevirt.io/v1
+    api_version: ssp.kubevirt.io/v1
     kind: KubevirtCommonTemplatesBundle
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
@@ -30,7 +30,7 @@
 
 - name: Set available condition
   k8s_status:
-    api_version: kubevirt.io/v1
+    api_version: ssp.kubevirt.io/v1
     kind: KubevirtCommonTemplatesBundle
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"

--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Set UseKVM condition
   k8s_status:
-    api_version: kubevirt.io/v1
+    api_version: ssp.kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
@@ -31,7 +31,7 @@
 
 - name: Set progressing condition
   k8s_status:
-    api_version: kubevirt.io/v1
+    api_version: ssp.kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
@@ -54,7 +54,7 @@
 
 - name: Set available condition
   k8s_status:
-    api_version: kubevirt.io/v1
+    api_version: ssp.kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
@@ -66,7 +66,7 @@
 
 - name: Set degraded condition 
   k8s_status:
-    api_version: kubevirt.io/v1
+    api_version: ssp.kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -29,7 +29,7 @@
 # there will be no attributes like availableReplicas and readyReplicas
 - name: Set progressing condition
   k8s_status:
-    api_version: kubevirt.io/v1
+    api_version: ssp.kubevirt.io/v1
     kind: KubevirtTemplateValidator
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
@@ -53,7 +53,7 @@
 
 - name: Set available condition
   k8s_status:
-    api_version: kubevirt.io/v1
+    api_version: ssp.kubevirt.io/v1
     kind: KubevirtTemplateValidator
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
@@ -65,7 +65,7 @@
 
 - name: Set degraded condition
   k8s_status:
-    api_version: kubevirt.io/v1
+    api_version: ssp.kubevirt.io/v1
     kind: KubevirtTemplateValidator
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"

--- a/watches.yaml
+++ b/watches.yaml
@@ -1,17 +1,17 @@
 ---
 - version: v1
-  group: kubevirt.io
+  group: ssp.kubevirt.io
   kind: KubevirtCommonTemplatesBundle
   playbook: /opt/ansible/commontemplatesbundle.yaml
 - version: v1
-  group: kubevirt.io
+  group: ssp.kubevirt.io
   kind: KubevirtTemplateValidator
   playbook: /opt/ansible/templatevalidator.yaml
 - version: v1
-  group: kubevirt.io
+  group: ssp.kubevirt.io
   kind: KubevirtNodeLabellerBundle
   playbook: /opt/ansible/kubevirtnodelabeller.yaml
 - version: v1
-  group: kubevirt.io
+  group: ssp.kubevirt.io
   kind: KubevirtMetricsAggregation
   playbook: /opt/ansible/metricsaggregation.yaml


### PR DESCRIPTION
The reason for this is to avoid that there are API clashes in the Kube API, where one operator is overriding the APIs of other operators.
Signed-off-by: Karel Simon <ksimon@redhat.com>