### PR TITLE
fix wrong api name

### DIFF
--- a/pkg/apis/kubevirt/v1/register.go
+++ b/pkg/apis/kubevirt/v1/register.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "kubevirt.io", Version: "v1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "ssp.kubevirt.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}


### PR DESCRIPTION
fix wrong api name
Because ssp is now using its own api group, HCO has to know about it.
Signed-off-by: Karel Simon <ksimon@redhat.com>