### PR TITLE
Dockerfile: update base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.11.0
+FROM quay.io/operator-framework/ansible-operator:v0.15.2
 
 LABEL org.kubevirt.hco.csv-generator.v1="/usr/bin/csv-generator"
 

--- a/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
@@ -17,7 +17,7 @@
     deployed_templates_after: "{{ lookup('k8s', api_version=ct_status.results[0].result.apiVersion, kind='template')|length }}"
 
 - name: Set progressing condition
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ssp.kubevirt.io/v1
     kind: KubevirtCommonTemplatesBundle
     name: "{{ meta.name }}"
@@ -29,7 +29,7 @@
       message: "Templates progressing."
 
 - name: Set available condition
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ssp.kubevirt.io/v1
     kind: KubevirtCommonTemplatesBundle
     name: "{{ meta.name }}"

--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -18,7 +18,7 @@
   register: nl_status
 
 - name: Set UseKVM condition
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ssp.kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
     name: "{{ meta.name }}"
@@ -30,7 +30,7 @@
       message: "KVM support is enabled."
 
 - name: Set progressing condition
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ssp.kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
     name: "{{ meta.name }}"
@@ -42,7 +42,7 @@
       message: "Node-labeller is progressing."
 
 - name:  "Wait for the node-labeller to start"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: "{{ nl.result.kind }}"
     name: "{{ nl.result.metadata.name }}"
@@ -53,7 +53,7 @@
   until: nl_status.resources[0].status.currentNumberScheduled == nl_status.resources[0].status.numberReady | default(false)
 
 - name: Set available condition
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ssp.kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
     name: "{{ meta.name }}"
@@ -65,7 +65,7 @@
       message: "Node-labeller is available."
 
 - name: Set degraded condition 
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ssp.kubevirt.io/v1
     kind: KubevirtNodeLabellerBundle
     name: "{{ meta.name }}"

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -28,7 +28,7 @@
 # defaults in this ansible code are here because at the start of deployment, there is a chance 
 # there will be no attributes like availableReplicas and readyReplicas
 - name: Set progressing condition
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ssp.kubevirt.io/v1
     kind: KubevirtTemplateValidator
     name: "{{ meta.name }}"
@@ -40,7 +40,7 @@
       message: "Template-validator is progressing."
 
 - name:  "Wait for the template-validator to start"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: "{{ tv_status.kind }}"
     name: "{{ tv_status.metadata.name }}"
@@ -52,7 +52,7 @@
 
 
 - name: Set available condition
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ssp.kubevirt.io/v1
     kind: KubevirtTemplateValidator
     name: "{{ meta.name }}"
@@ -64,7 +64,7 @@
       message: "Template-validator is available."
 
 - name: Set degraded condition
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ssp.kubevirt.io/v1
     kind: KubevirtTemplateValidator
     name: "{{ meta.name }}"


### PR DESCRIPTION
bump ansible-operator base image version
change k8s_status to use fully qualified collection name (https://github.com/operator-framework/operator-sdk/blob/587435a3f36047e60def802b10e525777411fa97/doc/ansible/dev/developer_guide.md#custom-resource-status-management)
replaced k8s_facts(it is deprecated) with k8s_info (https://github.com/operator-framework/operator-sdk/blob/770a2c529af64b2c32feb5a5c4a5058eedda3910/CHANGELOG.md)