### PR TITLE
Fix sorting of tags in hack/install-operator.sh

### DIFF
--- a/hack/install-operator.sh
+++ b/hack/install-operator.sh
@@ -18,7 +18,7 @@ LAST_TAG=""
 if [ "${CI}" != "true" ] || [ "${TRAVIS}" != "true" ]; then
 	# TODO: consume releases, not tags
 	# TODO: check if the github APIs guarantee the ordering
-	LAST_TAG=$( _curl -s https://api.github.com/repos/MarSik/kubevirt-ssp-operator/tags | jq -r '.[].name' | sort -r | head -1 )
+	LAST_TAG=$( _curl -s https://api.github.com/repos/MarSik/kubevirt-ssp-operator/tags | jq -r '.[].name' | sort -rV | head -1 )
 fi
 
 oc create -n ${NAMESPACE} -f ${BASEPATH}/../deploy/service_account.yaml


### PR DESCRIPTION
Previously an older version of the containter was installed,
because v1.0.9 was higher than v1.0.25.

Signed-off-by: Andrej Krejcir <akrejcir@redhat.com>