### PR TITLE
Add a rule required on k8s 1.17

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -39,6 +39,7 @@ rules:
   - clusterroles
   verbs:
   - create
+  - list
   - watch
   - patch
 - apiGroups:

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -100,6 +100,7 @@ spec:
           - clusterroles
           verbs:
           - create
+          - list
           - watch
           - patch
         - apiGroups:


### PR DESCRIPTION
The operator still reports a permission error on k8s 1.17:
`E0408 13:35:31.397749       8 reflector.go:123] pkg/mod/k8s.io/client-go@v0.0.0-20191016111102-bec269661e48/tools/cache/reflector.go:96: Failed to list *unstructured.Unstructured: clusterroles.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:kubevirt-hyperconverged:kubevirt-ssp-operator" cannot list resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope`

Adding the missing rule

Signed-off-by: Simone Tiraboschi stirabos@redhat.com