### PR TITLE
hardcode kubevirt version to v0.27.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,10 @@ before_script:
 ### And https://github.com/LiliC/travis-minikube/blob/e0f26f7b388057f51a0e2558afd5f990e07b6c49/.travis.yml#L11
 - sudo mount --make-rshared /
 
-- bash -x ci/ci/extra/get-kubevirt-releases
+## FIXME - kubevirt v0.28.0 uses functionality which os-3.11.0 doesn't support
+## we need to migrate tests to use OKD/OCP - 4.*
+## For now kubevirt version is hardcoded to v0.27.0
+#- bash -x ci/ci/extra/get-kubevirt-releases
 - bash -x ci/prepare-host $CPLATFORM
 - bash -x ci/prepare-host virtctl
 - bash -x ci/start-cluster $CPLATFORM $CVER

--- a/versionsrc
+++ b/versionsrc
@@ -1,0 +1,2 @@
+last=v0.27.0
+secondlast=v0.26.2


### PR DESCRIPTION
This change is needed, because travis tests are running on os-3.11.0 which doesn't
support kubevirt v0.28.0-rc.2. We need to migrate tests to OCP/OKD 4.*.

v0.28.0-rc.2 throws: error: unable to recognize "https://github.com/kubevirt/kubevirt/releases/download/v0.28.0-rc.2/kubevirt-operator.yaml": no matches for kind "PriorityClass" in version "scheduling.k8s.io/v1"

Signed-off-by: Karel Simon <ksimon@redhat.com>