### PR TITLE
[backport] fix labeller when no kvm device is available on the node

### DIFF
--- a/functests/06-test-deploy-node-labeller.sh
+++ b/functests/06-test-deploy-node-labeller.sh
@@ -14,26 +14,6 @@ oc apply -n ${TEST_NS} -f "${SCRIPTPATH}/node-labeller-unversioned-cr.yaml" || e
 
 wait_node_labeller_running ${TEST_NS} 5 60
 
-for idx in $( seq 1 30); do
-	echo "Waiting for node-labeller to label nodes"
-
-	number_of_cpu=$( oc get nodes -o json | jq '.items[0].metadata.labels | keys | map(select(startswith("feature.node.kubernetes.io/cpu-model-"))) | length')
-	number_of_cpu_features=$( oc get nodes -o json | jq '.items[0].metadata.labels | keys | map(select(startswith("feature.node.kubernetes.io/cpu-feature-"))) | length')
-
-	echo "Number of CPU labels: $number_of_cpu"
-	echo "Number of CPU features: $number_of_cpu_features"
-
-	if [ $number_of_cpu -gt 0 ] && [ $number_of_cpu_features -gt 0 ]; then
-		RET=0
-		break
-	fi
-	sleep 2s
-done
-
-if [ $RET -eq 1 ] ; then
-	exit 2
-fi
-
 #wait for ssp operator to set proper conditions
 wait_for_condition ${TEST_NS} 5 40 "KubevirtNodeLabellerBundle" "Available" "True"
 RET="$?"

--- a/functests/node-labeller-unversioned-cr.yaml
+++ b/functests/node-labeller-unversioned-cr.yaml
@@ -3,4 +3,3 @@ kind: KubevirtNodeLabellerBundle
 metadata:
   name: kubevirt-node-labeller-bundle
 spec:
-  useKVM: false

--- a/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/kubevirt-ssp-operator.vVERSION.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.7.0"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.1.1"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"templateValidatorReplicas":2,"version":"v0.6.2"}}]'
+    alm-examples: '[{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"templateValidatorReplicas":2,"version":"v0.6.2"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.7.0"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.1.1"}}]'
     capabilities: Basic Install
     categories: Openshift Optional
     containerImage: REPLACE_IMAGE

--- a/manifests/kubevirt-ssp-operator/latest/kubevirt-ssp-operator.latest.clusterserviceversion.yaml
+++ b/manifests/kubevirt-ssp-operator/latest/kubevirt-ssp-operator.latest.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.7.0"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.1.1"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"templateValidatorReplicas":2,"version":"v0.6.2"}}]'
+    alm-examples: '[{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtTemplateValidator","metadata":{"name":"kubevirt-template-validator","namespace":"kubevirt"},"spec":{"templateValidatorReplicas":2,"version":"v0.6.2"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtCommonTemplatesBundle","metadata":{"name":"kubevirt-common-template-bundle"},"spec":{"version":"v0.7.0"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtMetricsAggregation","metadata":{"name":"kubevirt-metrics-aggregation"},"spec":{"version":"v0.0.1"}},{"apiVersion":"ssp.kubevirt.io/v1","kind":"KubevirtNodeLabellerBundle","metadata":{"name":"kubevirt-node-labeller-bundle"},"spec":{"version":"v0.1.1"}}]'
     capabilities: Basic Install
     categories: Openshift Optional
     containerImage: REPLACE_IMAGE

--- a/pkg/apis/kubevirt/v1/types.go
+++ b/pkg/apis/kubevirt/v1/types.go
@@ -70,7 +70,6 @@ type VersionSpec struct {
 
 type ComponentSpec struct {
 	Version string `json:"version,omitempty"`
-	UseKVM  bool   `json:"useKVM"`
 }
 
 type TemplateValidatorSpec struct {

--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -17,18 +17,6 @@
     definition: "{{ lookup('k8s', kind=nl.result.kind, namespace=nl.result.metadata.namespace, resource_name=nl.result.metadata.name) | from_yaml }}"
   register: nl_status
 
-- name: Set UseKVM condition
-  operator_sdk.util.k8s_status:
-    api_version: ssp.kubevirt.io/v1
-    kind: KubevirtNodeLabellerBundle
-    name: "{{ meta.name }}"
-    namespace: "{{ meta.namespace }}"
-    conditions:
-    - type: KVMSupport
-      status: "{{ use_kvm }}"
-      reason: "enabled"
-      message: "KVM support is enabled."
-
 - name: Set progressing condition
   operator_sdk.util.k8s_status:
     api_version: ssp.kubevirt.io/v1

--- a/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
+++ b/roles/KubevirtNodeLabeller/templates/kubevirt-node-labeller-ds.yaml.j2
@@ -46,40 +46,24 @@ spec:
         - name: libvirt
           image: {{ ssp_registry | default('kubevirt') }}/{{ image_name_prefix }}{{ virt_launcher_image }}{{"@" if virt_launcher_tag.startswith("sha256:") else ":" }}{{ virt_launcher_tag }}
           command: ["/bin/sh","-c"]
-{% if use_kvm %}
-          args: ["libvirtd -d; chmod o+rw /dev/kvm; virsh domcapabilities --machine q35 --arch x86_64 --virttype kvm > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
-{% else %}
-          args: ["libvirtd -d; virsh domcapabilities --machine q35 --arch x86_64 --virttype qemu > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
-{% endif %}
+          args: ["if [ ! -e /dev/kvm ] && [ $(grep '\\<kvm\\>' /proc/misc | wc -l) -eq 0 ]; then echo 'exiting due to missing kvm device'; exit 0; fi; if [ ! -e /dev/kvm ]; then mknod /dev/kvm c 10 $(grep '\\<kvm\\>' /proc/misc | cut -f 1 -d' '); fi; libvirtd -d; chmod o+rw /dev/kvm; virsh domcapabilities --machine q35 --arch x86_64 --virttype kvm > /etc/kubernetes/node-feature-discovery/source.d/virsh_domcapabilities.xml; cp -r /usr/share/libvirt/cpu_map /etc/kubernetes/node-feature-discovery/source.d/"]
           imagePullPolicy: Always
-{% if use_kvm %}
           securityContext:
             privileged: true
-          resources:
-            requests:
-              devices.kubevirt.io/kvm: "1"
-            limits:
-              devices.kubevirt.io/kvm: "1"
-{% endif %}
           volumeMounts:
             - name: nfd-source
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
         - name: kubevirt-node-labeller
+          securityContext:
+            privileged: true
+          command: ["/bin/sh","-c"]
+          args: ["if [ ! -e /dev/kvm ] && [ $(grep '\\<kvm\\>' /proc/misc | wc -l) -eq 0 ]; then echo 'exiting due to missing kvm device'; exit 0; fi; if [ ! -e /dev/kvm ]; then mknod /dev/kvm c 10 $(grep '\\<kvm\\>' /proc/misc | cut -f 1 -d' '); fi; ./usr/sbin/node-labeller"]
           env:
           - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
           image: {{ ssp_registry | default('quay.io/kubevirt') }}/{{ image_name_prefix }}{{ kubevirt_node_labeller_image }}{{"@" if kubevirt_node_labeller_tag.startswith("sha256:") else ":" }}{{ kubevirt_node_labeller_tag }}
-{% if use_kvm %}
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              devices.kubevirt.io/kvm: "1"
-            limits:
-              devices.kubevirt.io/kvm: "1"
-{% endif %}
           volumeMounts:
             - name: nfd-source
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"


### PR DESCRIPTION
When node doesn't have access to kvm, labeller stays in pending state. This commit
removes the requirement for devices.kubevirt.io/kvm: "1". It adds new check which control
if pod has access to kvm device. If yes, everything goes as usual (binaries are copied, node is updated with new labels).
If kvm is not available, containers exit with 0 and no labells are added.

Signed-off-by: Karel Simon <ksimon@redhat.com>