### PR TITLE
[Backport] Patch resources instead of apply

### DIFF
--- a/roles/ClaimOwnership/tasks/main.yml
+++ b/roles/ClaimOwnership/tasks/main.yml
@@ -5,7 +5,7 @@
     state: present
     resource_definition:
       apiVersion: "{{ object.apiVersion }}"
-      kind: "{{ object.kind }}"
+      kind: "{{ objectKind | default(object.kind) }}"
       metadata:
         name: "{{ object.metadata.name }}"
         namespace: "{{ object.metadata.namespace }}"

--- a/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
+++ b/roles/KubevirtCommonTemplatesBundle/tasks/main.yml
@@ -15,14 +15,14 @@
     state: present
     namespace: "{{ cr_info.metadata.namespace }}"
     definition: "{{ item | from_yaml }}"
-    apply: yes
+    merge_type: ['merge', 'json']
   with_items: "{{ lookup('file', 'common-templates-'+ version +'.yaml').split('\n---\n') | select('search', '(^|\n)[^#]') | list }}"
   register: ct_status
 
 # Get all templates
 - name: Fetching all templates
   set_fact:
-    templates: "{{ lookup('k8s', api_version=ct_status.results[0].result.apiVersion, kind='template') }}"
+    templates: "{{ lookup('k8s', api_version=ct_status.results[0].result.apiVersion, kind='templates') }}"
 
 - block:
   - name: Fetch old CR
@@ -54,6 +54,7 @@
     name: ClaimOwnership
   vars:
     object: "{{ item }}"
+    objectKind: "templates"
     owner: "{{ cr_info }}"
   when: "{{ old_cr_exists==true }}"
   with_items: "{{ old_cr_templates }}" # Templates

--- a/roles/KubevirtMetricsAggregation/tasks/main.yml
+++ b/roles/KubevirtMetricsAggregation/tasks/main.yml
@@ -15,7 +15,7 @@
     state: present
     namespace: "{{ meta.namespace }}"
     definition: "{{ item | from_yaml }}"
-    apply: yes
+    merge_type: ['merge', 'json']
   with_items: "{{ lookup('template', 'aggregation-rule-vmi-count.yaml.j2').split('\n---\n') | select('search', '(^|\n)[^#]') |list }}"
   register: promrules
 

--- a/roles/KubevirtNodeLabeller/tasks/main.yml
+++ b/roles/KubevirtNodeLabeller/tasks/main.yml
@@ -13,7 +13,7 @@
   k8s:
     state: present
     definition: "{{ item | from_yaml }}"
-    apply: yes
+    merge_type: ['merge', 'json']
   with_items: "{{ lookup('template', 'kubevirt-node-labeller-roles.yaml.j2').split('\n---\n') | select('search', '(^|\n)[^#]') | list }}"
   register: roles
 
@@ -21,7 +21,7 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'kubevirt-node-labeller-ds.yaml.j2') | from_yaml }}"
-    apply: yes
+    merge_type: ['merge', 'json']
   register: nl
 
 # Actively inject owner references in order to adopt existing resources during an upgrade

--- a/roles/KubevirtTemplateValidator/tasks/main.yml
+++ b/roles/KubevirtTemplateValidator/tasks/main.yml
@@ -14,12 +14,12 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'template-view-role.yaml.j2') | from_yaml }}"
-    apply: yes
+    merge_type: ['merge', 'json']
 - name: Create the service
   k8s:
     state: present
     definition: "{{ item | from_yaml }}"
-    apply: yes
+    merge_type: ['merge', 'json']
   with_items: "{{ lookup('template', 'service.yaml.j2').split('\n---\n') | select('search', '(^|\n)[^#]') | list }}"
   register: tv
 
@@ -39,7 +39,7 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'webhook.yaml.j2') | from_yaml }}"
-    apply: yes
+    merge_type: ['merge', 'json']
   
 - name: Refresh template-validator var
   set_fact:


### PR DESCRIPTION
Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1853133
The k8s module's 'apply' options requires a version of the python2-openshift package that is not available downstream.
This commit replaces the 'apply' option with a merge/json patch (both are tried) that lifts this requirement.

This commit also makes sure the operator uses the 'templates' kind to prevent collisions with other resources, see: https://github.com/operator-framework/operator-sdk/issues/1380

Signed-off-by: Omer Yahud <oyahud@redhat.com>