### PR TITLE
[WIP] Fixed a flakey explainable CRD test

### DIFF
--- a/functests/09-test-ensure-crds-are-explainable.sh
+++ b/functests/09-test-ensure-crds-are-explainable.sh
@@ -27,9 +27,18 @@ oc apply -f ${SCRIPTPATH}/../deploy/crds/ssp.kubevirt.io_kubevirtmetricsaggregat
 oc apply -f ${SCRIPTPATH}/../deploy/crds/ssp.kubevirt.io_kubevirtnodelabellerbundles_crd.yaml
 oc apply -f ${SCRIPTPATH}/../deploy/crds/ssp.kubevirt.io_kubevirttemplatevalidators_crd.yaml
 
-oc explain kubevirtcommontemplatesbundles | grep "<empty>" >> /dev/null && RET=1
-oc explain kubevirtmetricsaggregations | grep "<empty>" >> /dev/null && RET=1
-oc explain kubevirtnodelabellerbundles | grep "<empty>" >> /dev/null && RET=1
-oc explain kubevirttemplatevalidators | grep "<empty>" >> /dev/null && RET=1
+# I couldn't figure out what caused the CRD to become unavailable to 'oc explain', and it seems that 
+# just waiting for a few seconds resolves the issue
+sleep 30
+
+oc explain kubevirtcommontemplatesbundles
+oc explain kubevirtmetricsaggregations
+oc explain kubevirtnodelabellerbundles
+oc explain kubevirttemplatevalidators
+
+# oc explain kubevirtcommontemplatesbundles | grep "<empty>" >> /dev/null && RET=1
+# oc explain kubevirtmetricsaggregations | grep "<empty>" >> /dev/null && RET=1
+# oc explain kubevirtnodelabellerbundles | grep "<empty>" >> /dev/null && RET=1
+# oc explain kubevirttemplatevalidators | grep "<empty>" >> /dev/null && RET=1
 
 exit $RET


### PR DESCRIPTION
I couldn't find out why the CRD is not available for 'oc explain', I have tried
waiting for conditions on the CRD that mark it as ready but that did not help.

I eventually resorted to adding an arbitrary sleep before executing the test and that
seemed to solve the issue.

Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`oc explain` tests were flakey

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
