### PR TITLE
Fix common-templates test exit code

### DIFF
--- a/functests/02-test-deploy-templates-openshift.sh
+++ b/functests/02-test-deploy-templates-openshift.sh
@@ -3,13 +3,12 @@
 SCRIPTPATH=$( dirname $(readlink -f $0) )
 source ${SCRIPTPATH}/testlib.sh
 
-RET=1
 TEST_NS="openshift"  # TODO: check this exists?
 
-oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
+oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 1
 
-oc wait -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" -n ${TEST_NS} --for=condition=Available --timeout=600s
+oc wait -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" -n ${TEST_NS} --for=condition=Available --timeout=600s || exit 2
 
-oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
+oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 3
 
-exit $RET
+exit 0

--- a/functests/03-test-deploy-templates-different-namespace.sh
+++ b/functests/03-test-deploy-templates-different-namespace.sh
@@ -3,15 +3,14 @@
 SCRIPTPATH=$( dirname $(readlink -f $0) )
 source ${SCRIPTPATH}/testlib.sh
 
-RET=1
 TEST_NS=$(uuidgen)
 
-oc create ns ${TEST_NS} || exit 2
+oc create ns ${TEST_NS} || exit 1
 oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
 
-oc wait -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" -n ${TEST_NS} --for=condition=Available --timeout=600s
+oc wait -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" -n ${TEST_NS} --for=condition=Available --timeout=600s || exit 3
 
-oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
-oc delete ns ${TEST_NS} || exit 2
+oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 4
+oc delete ns ${TEST_NS} || exit 5
 
-exit $RET
+exit 0

--- a/functests/04-test-deploy-templates-operator-namespace.sh
+++ b/functests/04-test-deploy-templates-operator-namespace.sh
@@ -5,13 +5,12 @@ source ${SCRIPTPATH}/testlib.sh
 
 [ -z ${SSP_OP_POD_NAMESPACE} ] && exit 127
 
-RET=1
 TEST_NS="${SSP_OP_POD_NAMESPACE}"
 
-oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
+oc create -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 1
 
-oc wait -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" -n ${TEST_NS} --for=condition=Available --timeout=600s
+oc wait -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" -n ${TEST_NS} --for=condition=Available --timeout=600s || exit 2
 
-oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 2
+oc delete -n ${TEST_NS} -f "${SCRIPTPATH}/common-templates-unversioned-cr.yaml" || exit 3
 
-exit $RET
+exit 0


### PR DESCRIPTION
Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Common-templates tests return a bad exit code when they succeed, this commit makes sure the proper exit codes are provided

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
