### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This project has been deprecated, and replaced by the [new SSP operator](https://github.com/kubevirt/ssp-operator).
+
 # kubevirt-ssp-operator
 Operator that manages Scheduling, Scale and Performance addons for [KubeVirt](https://kubevirt.io)
 


### PR DESCRIPTION

**What this PR does / why we need it**:
This project is deprecated in favor of the new SSP operator:
https://github.com/kubevirt/ssp-operator

**Release note**:
```release-note
This project is deprecated.
```
