### PR TITLE
Update aggregation-rule-vmi-count.yaml.j2

### DIFF
--- a/roles/KubevirtMetricsAggregation/templates/aggregation-rule-vmi-count.yaml.j2
+++ b/roles/KubevirtMetricsAggregation/templates/aggregation-rule-vmi-count.yaml.j2
@@ -12,5 +12,5 @@ spec:
   - name: cnv.rules
     rules:
     - expr: |
-        sum(kubevirt_vmi_phase_count{phase="running"}) by (node)
+        sum(kubevirt_vmi_phase_count{phase="running"}) by (node,os,flavor,workload)
       record: cnv:vmi_status_running:count


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added os, flavor and workload to the group by of cnv:vmi_status_running:count metric.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Check that the cnv:vmi_status_running:count metrics includes the additional labels for VMs that were created using templates that include them.

Signed-off-by: Shirly Radco sradco@redhat.com

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
